### PR TITLE
Fix initialization, database lifecycle, and build issues

### DIFF
--- a/AlbionTradeOptimizer.spec
+++ b/AlbionTradeOptimizer.spec
@@ -1,0 +1,71 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path.cwd()
+sys.path.insert(0, str(project_root))
+
+a = Analysis(
+    ['main.py'],
+    pathex=[str(project_root)],
+    binaries=[],
+    datas=[
+        ('config.yaml', '.'),
+        ('recipes/*.json', 'recipes'),
+        ('recipes/items.txt', 'recipes'),
+    ],
+    hiddenimports=[
+        'PySide6.QtCore',
+        'PySide6.QtWidgets',
+        'PySide6.QtGui',
+        'sqlalchemy.dialects.sqlite',
+        'sqlalchemy.pool',
+        'yaml',
+        'requests',
+        'pandas',
+        'numpy',
+        'jinja2',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        'tkinter',
+        'matplotlib',
+        'PIL',
+        'IPython',
+        'jupyter',
+        'notebook',
+        'sphinx',
+        'pytest',
+    ],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='AlbionTradeOptimizer',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,  # Set to True for debugging
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    version='version_info.txt',
+    icon='icon.ico' if Path('icon.ico').exists() else None,
+)

--- a/build.py
+++ b/build.py
@@ -61,12 +61,12 @@ a = Analysis(
     binaries=[],
     datas=[
         ('config.yaml', '.'),
-        ('recipes/recipes.json', 'recipes/'),
-        ('recipes/items.txt', 'recipes/'),
+        ('recipes/*.json', 'recipes'),
+        ('recipes/items.txt', 'recipes'),
     ],
     hiddenimports=[
         'PySide6.QtCore',
-        'PySide6.QtWidgets', 
+        'PySide6.QtWidgets',
         'PySide6.QtGui',
         'sqlalchemy.dialects.sqlite',
         'sqlalchemy.pool',
@@ -74,6 +74,7 @@ a = Analysis(
         'requests',
         'pandas',
         'numpy',
+        'jinja2',
     ],
     hookspath=[],
     hooksconfig={{}},
@@ -151,7 +152,7 @@ VSVersionInfo(
         StringStruct(u'FileDescription', u'Albion Trade Optimizer - Trade analysis tool for Albion Online'),
         StringStruct(u'FileVersion', u'{VERSION}'),
         StringStruct(u'InternalName', u'{PROJECT_NAME}'),
-        StringStruct(u'LegalCopyright', u'Copyright © 2025 Manus AI'),
+        StringStruct(u'LegalCopyright', u'Copyright (c) 2025 Manus AI'),
         StringStruct(u'OriginalFilename', u'{PROJECT_NAME}.exe'),
         StringStruct(u'ProductName', u'Albion Trade Optimizer'),
         StringStruct(u'ProductVersion', u'{VERSION}')])
@@ -288,7 +289,7 @@ def create_license():
         print("📄 Creating license file...")
         
         license_text = f'''Albion Trade Optimizer v{VERSION}
-Copyright © 2025 Manus AI
+Copyright (c) 2025 Manus AI
 
 This software is provided "as is" without warranty of any kind.
 

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -50,7 +50,9 @@ REM Test the application
 echo Testing application...
 python main.py --test
 if errorlevel 1 (
-    echo WARNING: Application test failed. Continuing with build...
+    echo ERROR: Application test failed.
+    pause
+    exit /b 1
 )
 
 REM Run build script

--- a/config.yaml
+++ b/config.yaml
@@ -34,13 +34,12 @@ crafting:
   focus_return_rate: 0.35      # 35% focus return rate
   default_station_fee: 0       # Default station fee
 
-# Albion Online Data Project API settings
-  aodp:
-    base_url: "https://www.albion-online-data.com/api/v2/stats"
-    server: "europe"             # Target game server
-    chunk_size: 40               # Items per API request
-    rate_delay_seconds: 1        # Delay between requests
-    timeout_seconds: 30          # Request timeout
+aodp:
+  base_url: "https://www.albion-online-data.com/api/v2/stats"
+  server: "europe"             # Target game server
+  chunk_size: 40               # Items per API request
+  rate_delay_seconds: 1        # Delay between requests
+  timeout_seconds: 30          # Request timeout
 
 # Application settings
 app:

--- a/engine/config.py
+++ b/engine/config.py
@@ -111,7 +111,7 @@ class ConfigManager:
             raise
     
     def get_default_config(self) -> Dict[str, Any]:
-        """Get default configuration (public method)."""
+        """Return default configuration values."""
         return self._get_default_config()
     
     def _get_default_config(self) -> Dict[str, Any]:

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -33,23 +33,12 @@ from store.db import DatabaseManager
 class MainWindow(QMainWindow):
     """Main application window."""
 
-
     def __init__(
         self,
         config: Optional[Dict[str, Any]] = None,
         db_manager: Optional[DatabaseManager] = None,
     ) -> None:
-        """Initialize the main window.
-
-        Parameters
-        ----------
-        config:
-            Optional pre-loaded configuration dictionary. If not provided, the
-            configuration is loaded using :class:`ConfigManager`.
-        db_manager:
-            Optional database manager instance. If not provided, a new
-            :class:`DatabaseManager` is created using the configuration.
-        """
+        """Initialize the main window."""
 
         super().__init__()
 
@@ -60,36 +49,24 @@ class MainWindow(QMainWindow):
         self.config = config or self.config_manager.load_config()
         self.db_manager = db_manager or DatabaseManager(self.config)
 
-    
-    def __init__(self):
-        """Initialize the main window."""
-        super().__init__()
-        
-        self.logger = logging.getLogger(__name__)
-        
-        # Initialize backend components
-        self.config_manager = ConfigManager()
-        self.config = self.config_manager.load_config()
-        self.db_manager = DatabaseManager(self.config)
-
         self.api_client = None
-        
+
         # Settings
         self.settings = QSettings('AlbionTradeOptimizer', 'AlbionTradeOptimizer')
-        
+
         # Initialize UI
         self.init_ui()
         self.init_menu_bar()
         self.init_tool_bar()
         self.init_status_bar()
         self.init_system_tray()
-        
+
         # Initialize backend
         self.init_backend()
-        
+
         # Restore window state
         self.restore_window_state()
-        
+
         # Start periodic updates
         self.init_timers()
     

--- a/gui/widgets/dashboard.py
+++ b/gui/widgets/dashboard.py
@@ -18,8 +18,8 @@ from PySide6.QtCore import Qt, QTimer, QThread, Signal
 from PySide6.QtGui import QFont, QPalette, QColor
 
 from engine.flips import FlipCalculator
-from engine.crafting import CraftingOptimizer, RecipeLoader
-from recipes.loader import RecipeLoader as RecipeLoaderClass
+from engine.crafting import CraftingOptimizer
+from recipes.loader import RecipeLoader
 
 
 class DashboardWidget(QWidget):
@@ -270,7 +270,7 @@ class DashboardWidget(QWidget):
             self.flip_calculator = FlipCalculator(config)
             
             # Initialize recipe loader and crafting optimizer
-            self.recipe_loader = RecipeLoaderClass()
+            self.recipe_loader = RecipeLoader()
             recipes = self.recipe_loader.load_recipes()
             
             if recipes:

--- a/gui/widgets/settings.py
+++ b/gui/widgets/settings.py
@@ -213,8 +213,7 @@ class SettingsWidget(QWidget):
             self.chunk_size_spin.setValue(aodp_config.get('chunk_size', 40))
             
             # Trading settings
-            fees_config = self.config.get('fees', {})
-            self.premium_check.setChecked(fees_config.get('premium', False))
+            self.premium_check.setChecked(self.config.get('premium_enabled', True))
             
             cities = self.config.get('cities', [])
             self.cities_edit.setText(','.join(cities))
@@ -253,9 +252,7 @@ class SettingsWidget(QWidget):
             config['aodp']['chunk_size'] = self.chunk_size_spin.value()
             
             # Trading settings
-            if 'fees' not in config:
-                config['fees'] = {}
-            config['fees']['premium'] = self.premium_check.isChecked()
+            config['premium_enabled'] = self.premium_check.isChecked()
             
             cities_text = self.cities_edit.text().strip()
             if cities_text:

--- a/version_info.txt
+++ b/version_info.txt
@@ -1,0 +1,32 @@
+# UTF-8
+#
+# For more details about fixed file info 'ffi' see:
+# http://msdn.microsoft.com/en-us/library/ms646997.aspx
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(1, 0, 0, 0),
+    prodvers=(1, 0, 0, 0),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x40004,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo(
+      [
+      StringTable(
+        u'040904B0',
+        [StringStruct(u'CompanyName', u'Manus AI'),
+        StringStruct(u'FileDescription', u'Albion Trade Optimizer - Trade analysis tool for Albion Online'),
+        StringStruct(u'FileVersion', u'1.0.0'),
+        StringStruct(u'InternalName', u'AlbionTradeOptimizer'),
+        StringStruct(u'LegalCopyright', u'Copyright (c) 2025 Manus AI'),
+        StringStruct(u'OriginalFilename', u'AlbionTradeOptimizer.exe'),
+        StringStruct(u'ProductName', u'Albion Trade Optimizer'),
+        StringStruct(u'ProductVersion', u'1.0.0')])
+      ]),
+    VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
+  ]
+)


### PR DESCRIPTION
## Summary
- unify `MainWindow` constructor and wire full initialization
- preserve database file and add lifecycle helpers
- standardize premium flag and API settings in config and UI
- simplify craft plan persistence and clean up imports
- include config and recipes in PyInstaller spec and fail fast on test errors

## Testing
- `pytest` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dbb275dc83308b69b65b147b18f1