### PR TITLE
Add market prices service and UI tab

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -25,6 +25,7 @@ from gui.widgets.flip_finder import FlipFinderWidget
 from gui.widgets.crafting_optimizer import CraftingOptimizerWidget
 from gui.widgets.settings import SettingsWidget
 from gui.widgets.data_manager import DataManagerWidget
+from gui.widgets.market_prices import MarketPricesWidget
 
 # Import backend components
 from engine.config import ConfigManager
@@ -79,14 +80,18 @@ class MainWindow(QMainWindow):
         # Flip Finder tab
         self.flip_finder_widget = FlipFinderWidget(self)
         self.tab_widget.addTab(self.flip_finder_widget, "💰 Flip Finder")
-        
+
         # Crafting Optimizer tab
         self.crafting_optimizer_widget = CraftingOptimizerWidget(self)
         self.tab_widget.addTab(self.crafting_optimizer_widget, "🔨 Crafting")
-        
+
         # Data Manager tab
         self.data_manager_widget = DataManagerWidget(self)
         self.tab_widget.addTab(self.data_manager_widget, "📡 Data")
+
+        # Market Prices tab
+        self.market_prices_widget = MarketPricesWidget(self)
+        self.tab_widget.addTab(self.market_prices_widget, "💹 Prices")
         
         # Settings tab
         self.settings_widget = SettingsWidget(self)

--- a/gui/widgets/market_prices.py
+++ b/gui/widgets/market_prices.py
@@ -1,0 +1,173 @@
+"""Widget for viewing market prices across cities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+import requests
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from services.market_prices import fetch_prices
+
+
+class MarketPricesWidget(QWidget):
+    """Tab for viewing live market prices."""
+
+    def __init__(self, main_window):
+        super().__init__()
+        self.main_window = main_window
+        self.logger = logging.getLogger(__name__)
+        self.rows: List[Dict[str, Any]] = []
+        self.summary: Dict[str, Dict[str, Any]] = {}
+        self.init_ui()
+
+    # ------------------------------------------------------------------
+    # UI
+    # ------------------------------------------------------------------
+    def init_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        controls = QHBoxLayout()
+        controls.addWidget(QLabel("Server:"))
+        self.server_combo = QComboBox()
+        self.server_combo.addItems(["europe", "asia", "americas"])
+        controls.addWidget(self.server_combo)
+
+        controls.addWidget(QLabel("Cities:"))
+        self.city_list = QListWidget()
+        self.city_list.setSelectionMode(QAbstractItemView.MultiSelection)
+        for city in [
+            "Bridgewatch",
+            "Martlock",
+            "Lymhurst",
+            "Thetford",
+            "Fort Sterling",
+            "Caerleon",
+        ]:
+            item = QListWidgetItem(city)
+            item.setSelected(True)
+            self.city_list.addItem(item)
+        controls.addWidget(self.city_list)
+
+        controls.addWidget(QLabel("Qualities:"))
+        self.quality_list = QListWidget()
+        self.quality_list.setSelectionMode(QAbstractItemView.MultiSelection)
+        for q in range(1, 6):
+            item = QListWidgetItem(str(q))
+            if q == 1:
+                item.setSelected(True)
+            self.quality_list.addItem(item)
+        controls.addWidget(self.quality_list)
+
+        layout.addLayout(controls)
+
+        body = QHBoxLayout()
+        self.table = QTableWidget(0, 10)
+        self.table.setHorizontalHeaderLabels(
+            [
+                "Icon",
+                "Item",
+                "City",
+                "Quality",
+                "Sell Min",
+                "Sell Max",
+                "Buy Max",
+                "Buy Min",
+                "Last Update Sell",
+                "Last Update Buy",
+            ]
+        )
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.table.setSelectionMode(QTableWidget.SingleSelection)
+        self.table.itemSelectionChanged.connect(self.update_summary_from_selection)
+        body.addWidget(self.table, 3)
+
+        side_widget = QWidget()
+        side_layout = QVBoxLayout(side_widget)
+        self.best_buy_label = QLabel("Best Buy: -")
+        self.best_sell_label = QLabel("Best Sell: -")
+        side_layout.addWidget(self.best_buy_label)
+        side_layout.addWidget(self.best_sell_label)
+        side_layout.addStretch()
+        body.addWidget(side_widget, 1)
+
+        layout.addLayout(body)
+
+    # ------------------------------------------------------------------
+    # Data handling
+    # ------------------------------------------------------------------
+    def load_prices(self, items: List[str]) -> None:
+        cities = [i.text() for i in self.city_list.selectedItems()]
+        qualities = [int(i.text()) for i in self.quality_list.selectedItems()]
+        server = self.server_combo.currentText()
+
+        try:
+            rows, summary = fetch_prices(items, cities, qualities, server)
+        except Exception as exc:  # pragma: no cover - network errors
+            self.logger.error("Failed to fetch prices: %s", exc)
+            return
+
+        self.rows = rows
+        self.summary = summary
+        self.populate_table()
+
+    def populate_table(self) -> None:
+        self.table.setRowCount(len(self.rows))
+        for row_index, row in enumerate(self.rows):
+            # Icon
+            icon_label = QLabel()
+            try:
+                response = requests.get(row["icon_url"], timeout=30)
+                pixmap = QPixmap()
+                pixmap.loadFromData(response.content)
+                icon_label.setPixmap(pixmap.scaled(40, 40, Qt.KeepAspectRatio))
+            except Exception:  # pragma: no cover - network failure
+                pass
+            self.table.setCellWidget(row_index, 0, icon_label)
+
+            self.table.setItem(row_index, 1, QTableWidgetItem(row["item_id"]))
+            self.table.setItem(row_index, 2, QTableWidgetItem(row["city"]))
+            self.table.setItem(row_index, 3, QTableWidgetItem(str(row["quality"])))
+            self.table.setItem(row_index, 4, QTableWidgetItem(str(row["sell_min"])))
+            self.table.setItem(row_index, 5, QTableWidgetItem(str(row["sell_max"])))
+            self.table.setItem(row_index, 6, QTableWidgetItem(str(row["buy_max"])))
+            self.table.setItem(row_index, 7, QTableWidgetItem(str(row["buy_min"])))
+            self.table.setItem(
+                row_index, 8, QTableWidgetItem(row["last_update_sell"] or "")
+            )
+            self.table.setItem(
+                row_index, 9, QTableWidgetItem(row["last_update_buy"] or "")
+            )
+
+    def update_summary_from_selection(self) -> None:
+        items = self.table.selectedItems()
+        if not items:
+            self.best_buy_label.setText("Best Buy: -")
+            self.best_sell_label.setText("Best Sell: -")
+            return
+        item_id = self.table.item(self.table.currentRow(), 1).text()
+        info = self.summary.get(item_id)
+        if not info:
+            return
+        bb = info["best_buy"]
+        bs = info["best_sell"]
+        if bb["city"] is not None:
+            self.best_buy_label.setText(f"Best Buy: {bb['city']} @ {bb['price']}")
+        if bs["city"] is not None:
+            self.best_sell_label.setText(f"Best Sell: {bs['city']} @ {bs['price']}")

--- a/services/market_prices.py
+++ b/services/market_prices.py
@@ -1,0 +1,181 @@
+"""Market price fetching utilities.
+
+Provides helper functions for retrieving and normalising market
+price information from the Albion Online Data API.  The core
+entry point is :func:`fetch_prices` which returns a list of
+normalised rows and a per-item summary describing the best place to
+buy and sell.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Tuple
+
+import requests
+
+API_BASE = "https://www.albion-online-data.com/api/v2/stats"
+RENDER_BASE = "https://render.albiononline.com/v1/item"
+
+# minimum delay between requests to respect 180 req/min limit
+_MIN_INTERVAL = 60.0 / 180.0
+_last_request: float = 0.0
+
+
+def _rate_limit() -> None:
+    """Simple rate limiter to roughly respect the API limits.
+
+    The Albion Online Data API allows 180 requests per minute.  We
+    keep track of the time of the last request and sleep if required
+    to maintain the minimum interval.  This is intentionally very
+    small and lightweight as the application typically bundles
+    multiple items and locations into a single request.
+    """
+
+    global _last_request
+    elapsed = time.time() - _last_request
+    if elapsed < _MIN_INTERVAL:
+        time.sleep(_MIN_INTERVAL - elapsed)
+    _last_request = time.time()
+
+
+def build_icon_url(item_id: str, quality: int = 1, size: int = 64) -> str:
+    """Return the URL to the rendered icon for ``item_id``.
+
+    Parameters
+    ----------
+    item_id:
+        The Albion item identifier, e.g. ``"T4_BAG"``.
+    quality:
+        Item quality (1-5).
+    size:
+        Icon size in pixels.  The API defaults to ``64`` so we mirror
+        that behaviour here.
+    """
+
+    return f"{RENDER_BASE}/{item_id}.png?quality={quality}&size={size}"
+
+
+def _parse_date(value: str | None) -> str | None:
+    """Parse API timestamp into ISO8601 UTC string.
+
+    The API sometimes omits the ``Z`` timezone designator; in that
+    case we assume UTC.
+    """
+
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        else:
+            dt = datetime.fromisoformat(value)
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return None
+
+
+def fetch_prices(
+    item_ids: Iterable[str],
+    cities: Iterable[str],
+    qualities: Iterable[int] | None = None,
+    server: str = "europe",
+) -> Tuple[List[Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+    """Fetch market prices for the given ``item_ids`` and ``cities``.
+
+    Parameters
+    ----------
+    item_ids:
+        Iterable of item identifiers.
+    cities:
+        Iterable of city names.
+    qualities:
+        Iterable of quality levels.  Defaults to ``[1]``.
+    server:
+        Game server region (``"europe"``, ``"asia"`` or ``"americas"``).
+
+    Returns
+    -------
+    rows, summary
+        ``rows`` is a list of dictionaries with normalised price
+        information.  ``summary`` maps each item id to a dictionary
+        describing the best place to buy (lowest ``sell_min``) and the
+        best place to sell (highest ``buy_max``).
+    """
+
+    item_ids = list(item_ids)
+    if not item_ids:
+        return [], {}
+
+    cities = list(cities)
+    qualities = list(qualities) if qualities is not None else [1]
+
+    items_str = ",".join(item_ids)
+    params = {
+        "locations": ",".join(cities),
+        "qualities": ",".join(map(str, qualities)),
+        "server": server,
+    }
+
+    url = f"{API_BASE}/prices/{items_str}.json"
+
+    _rate_limit()
+    response = requests.get(url, params=params, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    rows: List[Dict[str, Any]] = []
+    summary: Dict[str, Dict[str, Any]] = {}
+
+    for record in data:
+        item_id = record.get("item_id")
+        city = record.get("city")
+        quality = record.get("quality", 1)
+        sell_min = record.get("sell_price_min")
+        sell_max = record.get("sell_price_max")
+        buy_min = record.get("buy_price_min")
+        buy_max = record.get("buy_price_max")
+        last_sell = _parse_date(record.get("sell_price_min_date"))
+        last_buy = _parse_date(record.get("buy_price_max_date"))
+        icon_url = build_icon_url(item_id, quality)
+
+        row = {
+            "item_id": item_id,
+            "city": city,
+            "quality": quality,
+            "sell_min": sell_min,
+            "sell_max": sell_max,
+            "buy_min": buy_min,
+            "buy_max": buy_max,
+            "last_update_sell": last_sell,
+            "last_update_buy": last_buy,
+            "icon_url": icon_url,
+        }
+        rows.append(row)
+
+        # Update per-item summary
+        item_summary = summary.setdefault(
+            item_id,
+            {
+                "best_buy": {"city": None, "price": float("inf")},
+                "best_sell": {"city": None, "price": 0},
+            },
+        )
+        if sell_min is not None and sell_min < item_summary["best_buy"]["price"]:
+            item_summary["best_buy"] = {"city": city, "price": sell_min}
+        if buy_max is not None and buy_max > item_summary["best_sell"]["price"]:
+            item_summary["best_sell"] = {"city": city, "price": buy_max}
+
+    # Clean up infinities
+    for item_id, info in summary.items():
+        if info["best_buy"]["price"] == float("inf"):
+            info["best_buy"]["price"] = None
+        if info["best_sell"]["price"] == 0:
+            info["best_sell"]["price"] = None
+
+    return rows, summary
+
+
+__all__ = ["fetch_prices", "build_icon_url"]

--- a/tests/test_market_prices.py
+++ b/tests/test_market_prices.py
@@ -1,0 +1,66 @@
+import requests
+from datetime import datetime
+
+from services.market_prices import build_icon_url, fetch_prices
+
+
+def test_build_icon_url():
+    url = build_icon_url("T4_BAG", 2, 32)
+    assert url == "https://render.albiononline.com/v1/item/T4_BAG.png?quality=2&size=32"
+
+
+def test_fetch_prices_parses_and_summarises(monkeypatch):
+    sample = [
+        {
+            "item_id": "T4_BAG",
+            "city": "Bridgewatch",
+            "quality": 1,
+            "sell_price_min": 1000,
+            "sell_price_max": 1500,
+            "buy_price_min": 800,
+            "buy_price_max": 900,
+            "sell_price_min_date": "2024-01-01T10:00:00",
+            "buy_price_max_date": "2024-01-01T10:05:00",
+        },
+        {
+            "item_id": "T4_BAG",
+            "city": "Martlock",
+            "quality": 1,
+            "sell_price_min": 950,
+            "sell_price_max": 1400,
+            "buy_price_min": 850,
+            "buy_price_max": 950,
+            "sell_price_min_date": "2024-01-02T12:00:00",
+            "buy_price_max_date": "2024-01-02T12:05:00",
+        },
+    ]
+
+    class MockResponse:
+        def __init__(self, data):
+            self._data = data
+            self.status_code = 200
+
+        def json(self):
+            return self._data
+
+        def raise_for_status(self):
+            pass
+
+    def mock_get(url, params=None, timeout=30):
+        return MockResponse(sample)
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    rows, summary = fetch_prices(["T4_BAG"], ["Bridgewatch", "Martlock"])
+    assert len(rows) == 2
+    for row in rows:
+        assert isinstance(row["sell_min"], (int, float))
+        assert isinstance(row["buy_max"], (int, float))
+        # Ensure datetime can be parsed
+        datetime.fromisoformat(row["last_update_buy"].replace("Z", "+00:00"))
+        assert row["icon_url"].startswith(
+            "https://render.albiononline.com/v1/item/T4_BAG"
+        )
+
+    assert summary["T4_BAG"]["best_buy"] == {"city": "Martlock", "price": 950}
+    assert summary["T4_BAG"]["best_sell"] == {"city": "Martlock", "price": 950}


### PR DESCRIPTION
## Summary
- Implement market price service to fetch Albion Online prices with per-item summaries and icon URLs
- Introduce reusable icon URL builder and ISO8601 timestamp parsing
- Add Prices tab in GUI showing per-city buy/sell data and best buy/sell overview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fa18a138833097b395ecc7b91c9a