### PR TITLE
Add binary validation and centralized logging for Albion client

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from logging.handlers import RotatingFileHandler
+
+from platformdirs import user_log_dir
+
+_LOG_CONFIGURED = False
+
+FORMAT = (
+    "%(asctime)s | %(levelname)s | %(name)s | pid=%(process)d tid=%(threadName)s | %(message)s"
+)
+
+
+def _log_dir() -> Path:
+    if os.name == "nt":
+        base = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+        path = base / "AlbionTradeOptimizer" / "logs"
+    else:
+        path = Path(user_log_dir("AlbionTradeOptimizer"))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger configured for the application."""
+    global _LOG_CONFIGURED
+    if not _LOG_CONFIGURED:
+        log_dir = _log_dir()
+        file_handler = RotatingFileHandler(
+            log_dir / "app.log", maxBytes=2 * 1024 * 1024, backupCount=5, encoding="utf-8"
+        )
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter(FORMAT))
+
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(logging.INFO)
+        stream_handler.setFormatter(logging.Formatter(FORMAT))
+
+        root = logging.getLogger()
+        root.setLevel(logging.DEBUG)
+        root.addHandler(file_handler)
+        root.addHandler(stream_handler)
+        root.info("Log file: %s", file_handler.baseFilename)
+        _LOG_CONFIGURED = True
+    return logging.getLogger(name)

--- a/main.py
+++ b/main.py
@@ -5,14 +5,17 @@ Albion Trade Optimizer - Main Entry Point
 A desktop application for optimizing trade and crafting decisions in Albion Online.
 """
 
-import sys
 import os
-import logging
+import sys
 from pathlib import Path
 
 # Add the project root to Python path
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
+
+from logging_config import get_logger
+
+log = get_logger(__name__)
 
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import QDir
@@ -23,67 +26,41 @@ from store.db import DatabaseManager
 from engine.config import ConfigManager
 
 
-def setup_logging(config):
-    """Setup application logging."""
-    log_dir = Path(config.get('logging', {}).get('file', 'logs/albion_trade.log')).parent
-    log_dir.mkdir(parents=True, exist_ok=True)
-    
-    logging.basicConfig(
-        level=getattr(logging, config.get('logging', {}).get('level', 'INFO')),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=[
-            logging.FileHandler(config.get('logging', {}).get('file', 'logs/albion_trade.log')),
-            logging.StreamHandler(sys.stdout)
-        ]
-    )
-
-
-def setup_data_directory():
-    """Setup application data directory."""
-    data_dir = Path('data')
+def setup_data_directory() -> Path:
+    """Ensure the application data directory exists."""
+    data_dir = Path("data")
     data_dir.mkdir(parents=True, exist_ok=True)
     return data_dir
 
 
-def main():
+def main() -> int:
     """Main application entry point."""
-    # Create QApplication
     app = QApplication(sys.argv)
     app.setApplicationName("Albion Trade Optimizer")
     app.setApplicationVersion("1.0.0")
     app.setOrganizationName("Manus AI")
-    
+
     try:
-        # Load configuration
         config_manager = ConfigManager()
         config = config_manager.load_config()
-        
-        # Setup logging
-        setup_logging(config)
-        logger = logging.getLogger(__name__)
-        logger.info("Starting Albion Trade Optimizer")
-        
-        # Setup data directory
-        data_dir = setup_data_directory()
-        
-        # Initialize database
+
+        log.info("Starting Albion Trade Optimizer")
+
+        setup_data_directory()
+
         db_manager = DatabaseManager(config)
         db_manager.initialize_database()
-        
-        # Create and show main window
+
         main_window = MainWindow(config, db_manager)
         main_window.show()
-        
-        logger.info("Application started successfully")
-        
-        # Run the application
+
+        log.info("Application started successfully")
+
         return app.exec()
-        
-    except Exception as e:
-        logging.error(f"Failed to start application: {e}")
+    except Exception as e:  # pragma: no cover - startup errors
+        log.error("Failed to start application: %s", e)
         return 1
 
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/run_albiondata_client.bat
+++ b/run_albiondata_client.bat
@@ -1,10 +1,16 @@
 @echo off
-REM Launch albiondata-client.exe with proper quoting
-set "CLIENT_EXE=%~dp0bin\albiondata-client.exe"
+set "CLIENT=%~dp0bin\albiondata-client.exe"
+if not "%~1"=="" set "CLIENT=%~1"
 
-if not exist "%CLIENT_EXE%" (
-    echo albiondata-client.exe not found at "%CLIENT_EXE%"
+echo CLIENT: "%CLIENT%"
+for %%I in ("%CLIENT%") do set "SIZE=%%~zI"
+echo SIZE: %SIZE%
+
+powershell -NoLogo -NoProfile -Command "if(-not (Test-Path '%CLIENT%')){exit 1};$b=Get-Content -Encoding Byte -TotalCount 2 -Path '%CLIENT%';if([System.Text.Encoding]::ASCII.GetString($b) -ne 'MZ'){exit 1}"
+if errorlevel 1 (
+    echo albiondata-client.exe failed validation.
     exit /b 1
 )
 
-"%CLIENT_EXE%" %*
+echo Launching "%CLIENT%" %*
+"%CLIENT%" %*

--- a/services/albion_client.py
+++ b/services/albion_client.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional, Sequence
+
+from logging_config import get_logger
+from utils.pecheck import is_valid_win64_exe
+
+log = get_logger(__name__)
+
+DEFAULT_PROG_FILES = r"C:\Program Files\Albion Data Client\albiondata-client.exe"
+
+
+def _candidate_info(path: str) -> tuple[bool, int]:
+    exists = os.path.isfile(path)
+    size = os.path.getsize(path) if exists else 0
+    return exists, size
+
+
+def find_client(user_override: Optional[str], project_dir: Optional[str]) -> Optional[str]:
+    """Find a valid albiondata-client executable.
+
+    Candidates are checked in order: ``user_override`` -> ``DEFAULT_PROG_FILES`` ->
+    ``<project_dir>\\bin\\albiondata-client.exe``.  Each candidate is validated
+    with :func:`is_valid_win64_exe` and the outcome is logged.  The first valid
+    path is returned or ``None`` if none validate.
+    """
+    candidates = []
+    if user_override:
+        candidates.append(user_override)
+    candidates.append(DEFAULT_PROG_FILES)
+    if project_dir:
+        candidates.append(str(Path(project_dir) / "bin" / "albiondata-client.exe"))
+
+    for cand in candidates:
+        exists, size = _candidate_info(cand)
+        if exists:
+            valid, reason = is_valid_win64_exe(cand)
+        else:
+            valid, reason = False, "file does not exist"
+        log.info(
+            "Albion client candidate: %s -> valid=%s (%s) size=%s",
+            cand,
+            valid,
+            reason,
+            size,
+        )
+        if valid:
+            return cand
+    return None
+
+
+def launch_client(client_path: str, args: Sequence[str] = ()) -> subprocess.Popen:
+    """Validate and launch the albiondata-client executable.
+
+    :raises RuntimeError: if WinError 216 occurs or validation fails.
+    """
+    valid, reason = is_valid_win64_exe(client_path)
+    if not valid:
+        raise RuntimeError(f"Invalid albiondata-client.exe at {client_path}: {reason}")
+
+    cmd = [client_path, *args]
+    log.info("Launching albiondata-client: %s", cmd)
+    try:
+        proc = subprocess.Popen(cmd, close_fds=True)
+        log.info("Started PID=%s", proc.pid)
+        return proc
+    except OSError as exc:  # pragma: no cover - hard to trigger
+        if getattr(exc, "winerror", None) == 216:
+            msg = (
+                "Windows cannot run this albiondata-client.exe (WinError 216). "
+                "Install the official 64-bit Windows build and set its path in Settings."
+            )
+            log.error(msg)
+            raise RuntimeError(msg) from exc
+        log.exception("Failed to launch albiondata-client: %s", exc)
+        raise
+
+
+def capture_subproc_version(client_path: str, timeout: float = 3.0) -> None:
+    """Best-effort capture of ``--version`` output from the subprocess."""
+    try:
+        res = subprocess.run(
+            [client_path, "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            text=True,
+            close_fds=True,
+        )
+        log.debug(
+            "albiondata-client --version rc=%s stdout=%r stderr=%r",
+            res.returncode,
+            res.stdout.strip(),
+            res.stderr.strip(),
+        )
+    except Exception as exc:  # pragma: no cover - diagnostic only
+        log.debug("Failed to capture albiondata-client version: %s", exc)

--- a/tests/test_albion_client_backend.py
+++ b/tests/test_albion_client_backend.py
@@ -1,0 +1,28 @@
+import logging
+from pathlib import Path
+
+from logging_config import get_logger
+from services import albion_client
+
+
+def test_backend_skips_launch_on_invalid(monkeypatch, tmp_path, caplog):
+    get_logger('test')  # configure logging
+    fake = tmp_path / 'albiondata-client.exe'
+    fake.write_text('dummy')
+
+    monkeypatch.setattr('utils.pecheck.is_valid_win64_exe', lambda p: (False, 'wrong machine 0x014C'))
+
+    launched = {}
+    def fake_launch(*args, **kwargs):
+        launched['called'] = True
+    monkeypatch.setattr('services.albion_client.launch_client', fake_launch)
+
+    with caplog.at_level(logging.ERROR):
+        client = albion_client.find_client(str(fake), str(tmp_path))
+        if not client:
+            logging.getLogger('backend').error("Albion Data Client not found or invalid. Install the 64-bit client under 'C:\\Program Files\\Albion Data Client\\' or set a valid path in Settings.")
+        else:
+            albion_client.launch_client(client)
+
+    assert 'Albion Data Client not found or invalid' in caplog.text
+    assert 'called' not in launched

--- a/tests/test_pecheck.py
+++ b/tests/test_pecheck.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils.pecheck import is_valid_win64_exe
+
+
+def test_invalid_file_is_rejected(tmp_path):
+    p = tmp_path / "bad.exe"
+    p.write_text("Not an exe")
+    valid, reason = is_valid_win64_exe(str(p))
+    assert not valid
+    assert reason == "not MZ"
+
+
+@pytest.mark.skipif(os.name != 'nt', reason='windows only')
+def test_known_windows_binary():
+    path = Path(os.environ.get('WINDIR', r'C:\\Windows')) / 'System32' / 'notepad.exe'
+    if not path.exists():
+        pytest.skip('notepad.exe not available')
+    valid, reason = is_valid_win64_exe(str(path))
+    assert valid, reason

--- a/utils/pecheck.py
+++ b/utils/pecheck.py
@@ -1,0 +1,34 @@
+import os
+import struct
+
+def is_valid_win64_exe(path: str) -> tuple[bool, str]:
+    """Check whether ``path`` points to a valid 64-bit Windows executable.
+
+    Returns ``(True, "ok")`` when the file exists and contains a DOS header,
+    PE signature and the machine field ``0x8664``.  On failure ``False`` is
+    returned along with the specific reason.
+    """
+    if not os.path.isfile(path):
+        return False, "file does not exist"
+
+    try:
+        with open(path, "rb") as f:
+            if f.read(2) != b"MZ":
+                return False, "not MZ"
+            f.seek(0x3C)
+            e_lfanew_data = f.read(4)
+            if len(e_lfanew_data) != 4:
+                return False, "no e_lfanew"
+            e_lfanew = struct.unpack("<I", e_lfanew_data)[0]
+            f.seek(e_lfanew)
+            if f.read(4) != b"PE\0\0":
+                return False, "no PE signature"
+            machine_data = f.read(2)
+            if len(machine_data) != 2:
+                return False, "no machine"
+            machine = struct.unpack("<H", machine_data)[0]
+            if machine != 0x8664:
+                return False, f"wrong machine 0x{machine:04X}"
+        return True, "ok"
+    except Exception as exc:  # pragma: no cover - rare I/O issues
+        return False, str(exc)


### PR DESCRIPTION
## Summary
- validate Windows executables before launch to avoid WinError 216 pop-ups
- implement centralized rotating logging
- locate and start albiondata-client via new service with detailed diagnostics
- add tests for PE checks and backend handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b709ca6f508330a30a7f52f61b3cd3