### PR TITLE
Integrate automatic Albion Data Client fetching and resolution

### DIFF
--- a/services/albion_client.py
+++ b/services/albion_client.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional, Sequence
 
 from logging_config import get_logger
 from utils.pecheck import is_valid_win64_exe
-from .albion_client_fetch import download_client
+from .albion_client_fetch import fetch_latest_windows_client
 
 log = get_logger(__name__)
 
@@ -87,8 +87,10 @@ def find_client(
 
     if ask_download and ask_download():
         try:
-            download_client(MANAGED_CLIENT)
-            return str(MANAGED_CLIENT)
+            fetch_latest_windows_client(str(MANAGED_CLIENT), prefer_installer=False)
+            valid, _ = _log_candidate(MANAGED_CLIENT)
+            if valid:
+                return str(MANAGED_CLIENT)
         except Exception as exc:  # pragma: no cover - network issues
             log.error("Download failed: %s", exc)
     return None

--- a/services/albion_client_fetch.py
+++ b/services/albion_client_fetch.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import gzip
+import io
 import os
+import shutil
+import subprocess
 import tempfile
+import zipfile
 from pathlib import Path
+from typing import Any, Iterable, Optional, Callable
 
 import requests
 
@@ -11,38 +17,129 @@ from utils.pecheck import is_valid_win64_exe
 
 log = get_logger(__name__)
 
-DOWNLOAD_URL = (
-    "https://github.com/ao-data/albiondata-client/releases/latest/download/albiondata-client.exe"
+GITHUB_API_LATEST = "https://api.github.com/repos/ao-data/albiondata-client/releases/latest"
+DEFAULT_PROG_FILES = (
+    Path(os.environ.get("ProgramFiles", r"C:\\Program Files"))
+    / "Albion Data Client"
+    / "albiondata-client.exe"
 )
 
 
-def safe_atomic_write(dest: Path, data: bytes) -> None:
+class FetchError(RuntimeError):
+    pass
+
+
+def _pick_windows_asset(assets: Iterable[dict[str, Any]], prefer_installer: bool) -> Optional[dict[str, Any]]:
+    def match(predicate):
+        for asset in assets:
+            name = asset.get("name", "").lower()
+            if predicate(name):
+                return asset
+        return None
+
+    order: list[Callable[[str], bool]]
+    if prefer_installer:
+        order = [
+            lambda n: n.endswith("installer.exe"),
+            lambda n: n.endswith("update-windows-amd64.exe.gz"),
+        ]
+    else:
+        order = [
+            lambda n: n.endswith("update-windows-amd64.exe.gz"),
+            lambda n: n.endswith("installer.exe"),
+        ]
+    for pred in order:
+        asset = match(pred)
+        if asset:
+            return asset
+    return match(lambda n: "windows" in n and "amd64" in n and n.endswith(".zip"))
+
+
+def _gunzip_bytes_to_file(data: bytes, dest_exe_path: str) -> None:
+    dest = Path(dest_exe_path)
     dest.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=str(dest.parent))
+    with gzip.GzipFile(fileobj=io.BytesIO(data)) as gz:
+        extracted = gz.read()
+    with open(dest, "wb") as f:
+        f.write(extracted)
+        f.flush()
+        os.fsync(f.fileno())
+
+
+def _save_bytes(data: bytes, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())
+
+
+def fetch_latest_windows_client(dest_exe_path: str, prefer_installer: bool = False) -> str:
+    dest = Path(dest_exe_path)
     try:
-        with os.fdopen(fd, "wb") as f:
-            f.write(data)
-        os.replace(tmp, dest)
-    finally:
+        log.info("Fetching latest Albion Data Client release info")
+        resp = requests.get(GITHUB_API_LATEST, timeout=30)
+        resp.raise_for_status()
+        release = resp.json()
+    except Exception as exc:
+        log.exception("Failed to query GitHub releases: %s", exc)
+        raise FetchError("Failed to query GitHub releases") from exc
+
+    asset = _pick_windows_asset(release.get("assets", []), prefer_installer)
+    if not asset:
+        raise FetchError("No Windows asset found in latest release")
+
+    name = asset.get("name", "")
+    url = asset.get("browser_download_url")
+    log.info("Chosen asset %s (%s)", name, url)
+
+    try:
+        dl_resp = requests.get(url, timeout=60)
+        dl_resp.raise_for_status()
+        data = dl_resp.content
+    except Exception as exc:
+        log.exception("Failed to download asset: %s", exc)
+        raise FetchError("Failed to download Albion Data Client") from exc
+
+    if name.endswith(".exe.gz"):
+        log.info("Decompressing gzip asset %s", name)
+        _gunzip_bytes_to_file(data, dest_exe_path)
+    elif name.endswith("installer.exe"):
+        tmp_dir = Path(tempfile.mkdtemp())
+        installer_path = tmp_dir / name
+        _save_bytes(data, installer_path)
+        log.info("Running installer %s", installer_path)
         try:
-            os.unlink(tmp)
-        except FileNotFoundError:
-            pass
+            subprocess.run([str(installer_path), "/S"], check=True)
+        except Exception as exc:
+            log.warning("Silent installer run failed: %s", exc)
+            if prefer_installer:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                log.info("Falling back to portable download")
+                return fetch_latest_windows_client(dest_exe_path, prefer_installer=False)
+            raise FetchError("Failed to execute installer") from exc
+        try:
+            shutil.copy2(DEFAULT_PROG_FILES, dest)
+        except Exception as exc:
+            log.exception("Installer did not produce expected exe: %s", exc)
+            raise FetchError("Installer did not produce expected exe") from exc
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+    elif name.endswith(".zip"):
+        log.info("Extracting zip asset %s", name)
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            exe_name = next((n for n in zf.namelist() if n.lower().endswith(".exe")), None)
+            if not exe_name:
+                raise FetchError("Zip asset missing exe")
+            zf.extract(exe_name, dest.parent)
+            os.replace(dest.parent / exe_name, dest)
+    else:
+        raise FetchError(f"Unsupported asset type: {name}")
 
-
-def validate_or_raise(path: Path) -> None:
-    valid, reason = is_valid_win64_exe(str(path))
-    if not valid:
-        raise RuntimeError(f"invalid albiondata-client.exe: {reason}")
-
-
-def download_client(dest_path: Path, url: str = DOWNLOAD_URL) -> Path:
-    headers = {"User-Agent": "AlbionTradeOptimizer/1.0"}
-    log.info("Downloading Albion Data Client from %s", url)
-    resp = requests.get(url, timeout=30, headers=headers)
-    resp.raise_for_status()
-    safe_atomic_write(dest_path, resp.content)
-    size = dest_path.stat().st_size
-    log.info("Downloaded %s bytes to %s", size, dest_path)
-    validate_or_raise(dest_path)
-    return dest_path
+    ok, reason = is_valid_win64_exe(str(dest))
+    log.info("Downloaded client validation: %s (%s)", ok, reason)
+    if not ok:
+        raise FetchError(f"Downloaded client invalid: {reason}")
+    size = dest.stat().st_size
+    log.info("Albion client ready at %s size=%s", dest, size)
+    return str(dest)

--- a/tests/test_client_fetch.py
+++ b/tests/test_client_fetch.py
@@ -1,42 +1,90 @@
-import pytest
+import gzip
+import io
 from pathlib import Path
 
-from services.albion_client_fetch import download_client
+import pytest
+import requests
+
+from services import albion_client_fetch as fetcher
 
 
 class DummyResp:
-    def __init__(self, data: bytes):
+    def __init__(self, data=None, json_data=None):
         self.content = data
+        self._json = json_data
 
-    def raise_for_status(self) -> None:
+    def raise_for_status(self):
         pass
 
+    def json(self):
+        return self._json
 
-def test_download_client_valid(monkeypatch, tmp_path):
-    dest = tmp_path / "client.exe"
 
-    def fake_get(url, timeout, headers):
-        return DummyResp(b"data")
+def _compress(data: bytes) -> bytes:
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb") as gz:
+        gz.write(data)
+    return buf.getvalue()
 
-    monkeypatch.setattr("services.albion_client_fetch.requests.get", fake_get)
-    monkeypatch.setattr(
-        "utils.pecheck.is_valid_win64_exe", lambda p: (True, "ok")
+
+def test_pick_installer(monkeypatch, tmp_path):
+    assets = [
+        {"name": "albiondata-client-amd64-installer.exe", "browser_download_url": "u"}
+    ]
+    resp_release = DummyResp(json_data={"assets": assets})
+    resp_dl = DummyResp(data=b"installer")
+    calls = []
+
+    def fake_get(url, timeout):
+        calls.append(url)
+        return resp_dl if url == "u" else resp_release
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "DEFAULT_PROG_FILES", tmp_path / "pf" / "albiondata-client.exe")
+    fetcher.DEFAULT_PROG_FILES.parent.mkdir(parents=True)
+    fetcher.DEFAULT_PROG_FILES.write_bytes(b"exe")
+    monkeypatch.setattr(fetcher.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(fetcher, "is_valid_win64_exe", lambda p: (True, "ok"))
+
+    dest = tmp_path / "dest.exe"
+    assert (
+        fetcher.fetch_latest_windows_client(str(dest), prefer_installer=True)
+        == str(dest)
     )
+    assert dest.read_bytes() == b"exe"
+    assert calls == [fetcher.GITHUB_API_LATEST, "u"]
 
-    download_client(dest)
-    assert dest.exists()
+
+def test_pick_gz(monkeypatch, tmp_path):
+    data = _compress(b"exe")
+    assets = [
+        {"name": "update-windows-amd64.exe.gz", "browser_download_url": "u"}
+    ]
+    resp_release = DummyResp(json_data={"assets": assets})
+    resp_dl = DummyResp(data=data)
+
+    def fake_get(url, timeout):
+        return resp_dl if url == "u" else resp_release
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "is_valid_win64_exe", lambda p: (True, "ok"))
+
+    dest = tmp_path / "dest.exe"
+    fetcher.fetch_latest_windows_client(str(dest))
+    assert dest.read_bytes() == b"exe"
 
 
-def test_download_client_invalid(monkeypatch, tmp_path):
-    dest = tmp_path / "client.exe"
+def test_no_windows_asset(monkeypatch):
+    resp_release = DummyResp(json_data={"assets": []})
+    monkeypatch.setattr(fetcher.requests, "get", lambda u, timeout: resp_release)
+    with pytest.raises(fetcher.FetchError):
+        fetcher.fetch_latest_windows_client("x")
 
-    def fake_get(url, timeout, headers):
-        return DummyResp(b"data")
 
-    monkeypatch.setattr("services.albion_client_fetch.requests.get", fake_get)
-    monkeypatch.setattr(
-        "utils.pecheck.is_valid_win64_exe", lambda p: (False, "bad")
-    )
+def test_download_error(monkeypatch):
+    def fake_get(url, timeout):
+        raise requests.Timeout("boom")
 
-    with pytest.raises(RuntimeError):
-        download_client(dest)
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    with pytest.raises(fetcher.FetchError):
+        fetcher.fetch_latest_windows_client("x")

--- a/tests/test_client_resolution.py
+++ b/tests/test_client_resolution.py
@@ -4,56 +4,109 @@ import pytest
 from services import albion_client
 
 
-def test_resolution_order(monkeypatch, tmp_path):
+def setup_paths(tmp_path):
     appdata = tmp_path / "AppData" / "AlbionTradeOptimizer" / "bin"
-    appdata.mkdir(parents=True)
     managed = appdata / "albiondata-client.exe"
     prog = tmp_path / "Program Files" / "Albion Data Client" / "albiondata-client.exe"
-    prog.parent.mkdir(parents=True)
     override = tmp_path / "override.exe"
-    for p in (managed, prog, override):
-        p.write_text("x")
+    appdata.mkdir(parents=True, exist_ok=True)
+    prog.parent.mkdir(parents=True, exist_ok=True)
+    return appdata, managed, prog, override
+
+
+def test_resolution_override(monkeypatch, tmp_path):
+    appdata, managed, prog, override = setup_paths(tmp_path)
+    override.write_text("x")
 
     monkeypatch.setattr(albion_client, "APPDATA_BIN", appdata)
     monkeypatch.setattr(albion_client, "MANAGED_CLIENT", managed)
     monkeypatch.setattr(albion_client, "DEFAULT_PROG_FILES", str(prog))
-
     monkeypatch.setattr(
-        "services.albion_client.is_valid_win64_exe",
+        albion_client,
+        "is_valid_win64_exe",
         lambda p: (True, "ok") if p == str(override) else (False, "bad"),
     )
+
     assert albion_client.find_client(str(override)) == str(override)
 
+
+def test_resolution_appdata(monkeypatch, tmp_path):
+    appdata, managed, prog, _ = setup_paths(tmp_path)
+    managed.write_text("x")
+
+    monkeypatch.setattr(albion_client, "APPDATA_BIN", appdata)
+    monkeypatch.setattr(albion_client, "MANAGED_CLIENT", managed)
+    monkeypatch.setattr(albion_client, "DEFAULT_PROG_FILES", str(prog))
     monkeypatch.setattr(
-        "services.albion_client.is_valid_win64_exe",
+        albion_client,
+        "is_valid_win64_exe",
         lambda p: (True, "ok") if p == str(managed) else (False, "bad"),
     )
+
     assert albion_client.find_client(None) == str(managed)
 
+
+def test_resolution_program_files(monkeypatch, tmp_path):
+    appdata, managed, prog, _ = setup_paths(tmp_path)
+    prog.write_text("x")
+
+    monkeypatch.setattr(albion_client, "APPDATA_BIN", appdata)
+    monkeypatch.setattr(albion_client, "MANAGED_CLIENT", managed)
+    monkeypatch.setattr(albion_client, "DEFAULT_PROG_FILES", str(prog))
     monkeypatch.setattr(
-        "services.albion_client.is_valid_win64_exe",
+        albion_client,
+        "is_valid_win64_exe",
         lambda p: (True, "ok") if p == str(prog) else (False, "bad"),
     )
+
     assert albion_client.find_client(None) == str(prog)
 
 
-def test_embedded_fallback(monkeypatch, tmp_path):
-    appdata = tmp_path / "AppData" / "AlbionTradeOptimizer" / "bin"
-    managed = appdata / "albiondata-client.exe"
-    emb = tmp_path / "embedded" / "resources" / "windows" / "albiondata-client.exe"
+def test_embedded_copies(monkeypatch, tmp_path):
+    appdata, managed, prog, _ = setup_paths(tmp_path)
+    emb = tmp_path / "emb" / "resources" / "windows" / "albiondata-client.exe"
     emb.parent.mkdir(parents=True)
     emb.write_text("x")
 
     monkeypatch.setattr(albion_client, "APPDATA_BIN", appdata)
     monkeypatch.setattr(albion_client, "MANAGED_CLIENT", managed)
+    monkeypatch.setattr(albion_client, "DEFAULT_PROG_FILES", str(prog))
+    monkeypatch.setattr(albion_client, "_embedded_client_path", lambda: emb)
     monkeypatch.setattr(
-        "services.albion_client._embedded_client_path", lambda: emb
-    )
-    monkeypatch.setattr(
-        "services.albion_client.is_valid_win64_exe",
+        albion_client,
+        "is_valid_win64_exe",
         lambda p: (True, "ok"),
     )
 
     result = albion_client.find_client(None)
     assert result == str(managed)
     assert managed.exists()
+
+
+def test_download_called(monkeypatch, tmp_path):
+    appdata, managed, prog, _ = setup_paths(tmp_path)
+
+    monkeypatch.setattr(albion_client, "APPDATA_BIN", appdata)
+    monkeypatch.setattr(albion_client, "MANAGED_CLIENT", managed)
+    monkeypatch.setattr(albion_client, "DEFAULT_PROG_FILES", str(prog))
+    monkeypatch.setattr(albion_client, "_embedded_client_path", lambda: Path("missing"))
+    monkeypatch.setattr(
+        albion_client,
+        "is_valid_win64_exe",
+        lambda p: (True, "ok") if p == str(managed) else (False, "bad"),
+    )
+
+    called = {}
+
+    def fake_fetch(dest, prefer_installer=False):
+        called["yes"] = True
+        dest_path = Path(dest)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_text("x")
+        return str(dest_path)
+
+    monkeypatch.setattr(albion_client, "fetch_latest_windows_client", fake_fetch)
+
+    result = albion_client.find_client(None, ask_download=lambda: True)
+    assert result == str(managed)
+    assert called


### PR DESCRIPTION
## Summary
- add GitHub release fetcher that selects installer or portable assets and validates PE files
- expand client resolver to log candidates, copy embedded builds, and download on demand
- expose settings buttons to browse, use Program Files, use bundled, or download latest client
- add tests for resolver paths and release asset handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71891a1248330b466315ece00465b