### PR TITLE
Handle unsupported albiondata-client flags with fallback

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -169,6 +169,9 @@ class ConfigManager:
                 'binary_path_win': None,
                 'binary_path_linux': None,
             },
+            'client': {
+                'flags': [],
+            },
             'app': {
                 'name': "Albion Trade Optimizer",
                 'version': "1.0.0",

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -32,7 +32,11 @@ from gui.widgets.market_prices import MarketPricesWidget
 from engine.config import ConfigManager
 from datasources.aodp import AODPClient
 from store.db import DatabaseManager
-from services.albion_client import find_client, launch_client, capture_subproc_version
+from services.albion_client import (
+    find_client,
+    launch_client_with_fallback,
+    capture_subproc_version,
+)
 
 
 class MainWindow(QMainWindow):
@@ -226,7 +230,10 @@ class MainWindow(QMainWindow):
                 self.logger.error("Albion Data Client not found or invalid. Install the 64-bit client under 'C:\\Program Files\\Albion Data Client\\' or set a valid path in Settings.")
             else:
                 try:
-                    self.albion_proc = launch_client(client_path, args=("--once",))
+                    flags = list(self.config.get("client", {}).get("flags", []))
+                    self.albion_proc = launch_client_with_fallback(
+                        client_path, flags
+                    )
                     capture_subproc_version(client_path)
                 except Exception as e:
                     self.logger.exception("Failed to initialize backend components: %s", e)
@@ -284,7 +291,8 @@ class MainWindow(QMainWindow):
                 self.logger.error("Albion Data Client not found or invalid. Install the 64-bit client under 'C:\\Program Files\\Albion Data Client\\' or set a valid path in Settings.")
                 return
             try:
-                self.albion_proc = launch_client(client_path)
+                flags = list(self.config.get("client", {}).get("flags", []))
+                self.albion_proc = launch_client_with_fallback(client_path, flags)
             except Exception as e:
                 self.logger.exception("Failed to launch Albion Data Client: %s", e)
         else:

--- a/tests/test_albion_client_launch.py
+++ b/tests/test_albion_client_launch.py
@@ -1,0 +1,115 @@
+import logging
+import subprocess
+
+from logging_config import get_logger
+
+from services.albion_client import launch_client_with_fallback
+
+
+class _PopenMock:
+    """Simple Popen mock to control communicate behaviour."""
+
+    def __init__(self, cmd, behavior):
+        self.cmd = cmd
+        self._behavior = behavior
+        self.returncode = behavior.get("returncode")
+        self.pid = behavior.get("pid", 1234)
+
+    def communicate(self, timeout=None):  # pragma: no cover - behavior driven
+        if "exc" in self._behavior:
+            raise self._behavior["exc"]
+        return self._behavior.get("output", b""), b""
+
+    def kill(self):  # pragma: no cover - not relevant for test behaviour
+        pass
+
+
+def _prepare_popen(monkeypatch, behaviors):
+    calls = []
+
+    def fake_popen(cmd, **kwargs):
+        behavior = behaviors[len(calls)]
+        proc = _PopenMock(cmd, behavior)
+        calls.append(proc)
+        return proc
+
+    monkeypatch.setattr("services.albion_client.subprocess.Popen", fake_popen)
+    return calls
+
+
+def _patch_common(monkeypatch):
+    get_logger("test")
+    monkeypatch.setattr(
+        "services.albion_client.is_valid_win64_exe", lambda p: (True, "")
+    )
+
+
+def test_flag_rejection_triggers_fallback(monkeypatch, caplog):
+    _patch_common(monkeypatch)
+
+    monkeypatch.setattr(
+        "services.albion_client.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, b"", b""),
+    )
+
+    behaviors = [
+        {
+            "output": b"flag provided but not defined: -minimize\n",
+            "returncode": 1,
+        },
+        {"exc": subprocess.TimeoutExpired(cmd="x", timeout=2)},
+        {},
+    ]
+    calls = _prepare_popen(monkeypatch, behaviors)
+
+    with caplog.at_level(logging.INFO):
+        proc = launch_client_with_fallback("client.exe", ["-minimize"])
+
+    assert calls[0].cmd == ["client.exe", "-minimize"]
+    assert calls[1].cmd == ["client.exe"]
+    assert calls[2].cmd == ["client.exe"]
+    assert proc is calls[2]
+    assert "Client rejected flags" in caplog.text
+
+
+def test_preferred_flags_work(monkeypatch):
+    _patch_common(monkeypatch)
+
+    monkeypatch.setattr(
+        "services.albion_client.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, b"", b""),
+    )
+
+    behaviors = [
+        {"exc": subprocess.TimeoutExpired(cmd="x", timeout=2)},
+        {},
+    ]
+    calls = _prepare_popen(monkeypatch, behaviors)
+
+    proc = launch_client_with_fallback("client.exe", ["-minimize"])
+
+    assert calls[0].cmd == ["client.exe", "-minimize"]
+    assert calls[1].cmd == ["client.exe", "-minimize"]
+    assert proc is calls[1]
+
+
+def test_version_probe_failure_ignored(monkeypatch):
+    _patch_common(monkeypatch)
+
+    monkeypatch.setattr(
+        "services.albion_client.subprocess.run",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("missing")),
+    )
+
+    behaviors = [
+        {"exc": subprocess.TimeoutExpired(cmd="x", timeout=2)},
+        {},
+    ]
+    calls = _prepare_popen(monkeypatch, behaviors)
+
+    proc = launch_client_with_fallback("client.exe", [])
+
+    assert calls[0].cmd == ["client.exe"]
+    assert calls[1].cmd == ["client.exe"]
+    assert proc is calls[1]
+


### PR DESCRIPTION
## Summary
- allow config-driven `client.flags` list to set optional startup flags
- add robust `launch_client_with_fallback` probing `-version` and retrying without flags when rejected
- update GUI to use the new launcher and drop unsupported `--once`
- add tests covering flag rejection and version probe behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71ea3580c83308ccfdc8fff1f0cf2