### PR TITLE
Fix refresh workflow, unify sessions, and improve health checks

### DIFF
--- a/datasources/http.py
+++ b/datasources/http.py
@@ -1,0 +1,9 @@
+import requests
+_session = None
+
+def get_shared_session():
+    global _session
+    if _session is None:
+        _session = requests.Session()
+        _session.headers.update({"User-Agent": "AlbionTradeOptimizer/1.0"})
+    return _session

--- a/gui/widgets/market_prices.py
+++ b/gui/widgets/market_prices.py
@@ -48,7 +48,8 @@ class MarketPricesWidget(QWidget):
         controls = QHBoxLayout()
         controls.addWidget(QLabel("Server:"))
         self.server_combo = QComboBox()
-        self.server_combo.addItems(["europe", "asia", "americas"])
+        # Use region keys expected by the data service
+        self.server_combo.addItems(["europe", "east", "west"])
         controls.addWidget(self.server_combo)
 
         controls.addWidget(QLabel("Cities:"))
@@ -182,7 +183,8 @@ class MarketPricesWidget(QWidget):
         cities = [i.text() for i in self.city_list.selectedItems()]
         qualities = [int(i.text()) for i in self.quality_list.selectedItems()]
         server = self.server_combo.currentText()
-        return {"server": server, "city": cities[0] if cities else "", "qualities": qualities}
+        # Return all selected cities rather than collapsing to the first
+        return {"server": server, "cities": cities, "qualities": qualities}
 
     def on_refresh_clicked(self) -> None:
         if self.refresh_running:
@@ -202,7 +204,8 @@ class MarketPricesWidget(QWidget):
         from gui.threads import RefreshWorker
 
         self._thread = QThread(self)
-        self._worker = RefreshWorker(params)
+        # Pass application settings so the worker can honour fetch_all_items
+        self._worker = RefreshWorker(params, settings=self.main_window.settings)
         self._worker.moveToThread(self._thread)
         self._thread.started.connect(self._worker.run)
         self._worker.progress.connect(self.on_refresh_progress)

--- a/tests/test_health_store.py
+++ b/tests/test_health_store.py
@@ -32,11 +32,11 @@ def test_health_requires_three_failures(monkeypatch):
     monkeypatch.setattr(aurl, "base_for", lambda s: s)
     store.aodp_online = True
     store._fails = 0
-    ping_aodp("http://x", session)
+    ping_aodp("west", session)
     assert store.aodp_online
-    ping_aodp("http://x", session)
+    ping_aodp("west", session)
     assert store.aodp_online
-    ping_aodp("http://x", session)
+    ping_aodp("west", session)
     assert not store.aodp_online
 
 
@@ -48,7 +48,7 @@ def test_health_429_is_online(monkeypatch):
     monkeypatch.setattr(aurl, "base_for", lambda s: s)
     store.aodp_online = False
     store._fails = 5
-    ping_aodp("http://x", session)
+    ping_aodp("west", session)
     assert store.aodp_online and store._fails == 0
 
 
@@ -62,8 +62,8 @@ def test_success_resets_failures(monkeypatch):
     monkeypatch.setattr(aurl, "base_for", lambda s: s)
     store.aodp_online = True
     store._fails = 0
-    ping_aodp("http://x", session)
+    ping_aodp("west", session)
     assert store._fails == 1
-    ping_aodp("http://x", session)
+    ping_aodp("west", session)
     assert store.aodp_online and store._fails == 0
 

--- a/tests/test_server_mapping.py
+++ b/tests/test_server_mapping.py
@@ -1,0 +1,13 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from datasources.aodp_url import base_for
+
+
+def test_server_mapping_keys():
+    assert base_for('west').startswith('https://west')
+    assert base_for('east').startswith('https://east')
+    assert base_for('europe').startswith('https://europe')
+    # unknown keys fall back to europe
+    assert base_for('americas').startswith('https://europe')
+    assert base_for('asia').startswith('https://europe')


### PR DESCRIPTION
## Summary
- Update Prices tab to use east/west/europe servers and return all selected cities to the refresh worker
- Route refresh through new chunked price service with shared HTTP session
- Rework health ping to use same session and price endpoint, allowing 3 failures before offline
- Provide shared requests session helper and adjust data source to drop placeholder T4_BAG
- Add server mapping test and update health tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ac04ec8c8330b8d8c093c4c86a0d