### PR TITLE
Replace demo UI with live data and health checks

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -363,7 +363,7 @@ class MainWindow(QMainWindow):
     def show_quick_search(self):
         """Show quick search dialog."""
         # This will be implemented later
-        self.show_info("Quick Search", "Quick search feature coming soon!")
+        self.show_info("Quick Search", "Quick search not yet implemented")
     
     def show_about(self):
         """Show about dialog."""

--- a/gui/widgets/crafting_optimizer.py
+++ b/gui/widgets/crafting_optimizer.py
@@ -36,8 +36,8 @@ class CraftingOptimizerWidget(QWidget):
         # Create header
         self.create_header(layout)
         
-        # Create placeholder content
-        self.create_placeholder_content(layout)
+        # Create empty state content
+        self.create_empty_state(layout)
     
     def create_header(self, parent_layout):
         """Create header with title."""
@@ -57,28 +57,16 @@ class CraftingOptimizerWidget(QWidget):
         
         parent_layout.addWidget(header_frame)
     
-    def create_placeholder_content(self, parent_layout):
-        """Create placeholder content."""
+    def create_empty_state(self, parent_layout):
+        """Create empty state content."""
         content_group = QGroupBox("Crafting Analysis")
         content_layout = QVBoxLayout(content_group)
         
-        # Placeholder message
-        placeholder_label = QLabel("""
-        🔨 Crafting Optimizer - Coming Soon!
-        
-        This feature will include:
-        • Recipe profitability analysis
-        • Material cost optimization
-        • Production chain planning
-        • Focus efficiency calculations
-        • Station fee comparisons
-        
-        The backend crafting engine is already implemented.
-        GUI implementation is in progress.
-        """)
-        placeholder_label.setAlignment(Qt.AlignCenter)
-        placeholder_label.setStyleSheet("color: gray; font-size: 14px;")
-        content_layout.addWidget(placeholder_label)
+        # Empty state message
+        msg = QLabel("No crafting data yet — feature not implemented")
+        msg.setAlignment(Qt.AlignCenter)
+        msg.setStyleSheet("color: gray; font-size: 14px;")
+        content_layout.addWidget(msg)
         
         parent_layout.addWidget(content_group)
         parent_layout.addStretch()

--- a/gui/widgets/dashboard.py
+++ b/gui/widgets/dashboard.py
@@ -1,490 +1,100 @@
-"""
-Dashboard widget for Albion Trade Optimizer.
+"""Minimal dashboard rendering real market summaries."""
 
-Provides an overview of market data, opportunities, and system status.
-"""
-
-import logging
-from datetime import datetime, timedelta
-from typing import List, Dict, Any, Optional
+from __future__ import annotations
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout,
-    QLabel, QPushButton, QTableWidget, QTableWidgetItem,
-    QGroupBox, QScrollArea, QFrame, QProgressBar,
-    QHeaderView, QAbstractItemView
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
 )
-from PySide6.QtCore import Qt, QTimer, QThread, Signal
-from PySide6.QtGui import QFont, QPalette, QColor
+from PySide6.QtCore import Qt
 
-from engine.flips import FlipCalculator
-from engine.crafting import CraftingOptimizer
-from recipes.loader import RecipeLoader
 from core.signals import signals
-from utils.timefmt import to_utc, rel_age, fmt_tooltip
+from utils.timefmt import rel_age, fmt_tooltip
 
 
 class DashboardWidget(QWidget):
-    """Dashboard widget showing overview information."""
-    
-    def __init__(self, main_window):
-        """Initialize dashboard widget."""
-        super().__init__()
-        
-        self.main_window = main_window
-        self.logger = logging.getLogger(__name__)
-        
-        # Initialize components
-        self.flip_calculator = None
-        self.crafting_optimizer = None
-        self.recipe_loader = None
-        
-        # Data cache
-        self.cached_opportunities = []
-        self.cached_crafting_plans = []
-        self.last_update = None
-        
-        self.init_ui()
-        self.init_backend()
+    """Dashboard showing last update, record count and top opportunities."""
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self._build_ui()
         signals.market_data_ready.connect(self.on_market_data_ready)
-    
-    def init_ui(self):
-        """Initialize the user interface."""
+        self.set_loading_state(True)
+
+    # ------------------------------------------------------------------
+    # UI helpers
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(10, 10, 10, 10)
-        layout.setSpacing(10)
-        
-        # Create header
-        self.create_header(layout)
-        
-        # Create main content area
-        self.create_main_content(layout)
-        
-        # Create footer
-        self.create_footer(layout)
-    
-    def create_header(self, parent_layout):
-        """Create dashboard header."""
-        header_frame = QFrame()
-        header_frame.setFrameStyle(QFrame.StyledPanel)
-        header_layout = QHBoxLayout(header_frame)
-        
-        # Title
-        title_label = QLabel("📊 Market Dashboard")
-        title_font = QFont()
-        title_font.setPointSize(16)
-        title_font.setBold(True)
-        title_label.setFont(title_font)
-        header_layout.addWidget(title_label)
-        
-        header_layout.addStretch()
-        
-        # Last update label
-        self.last_update_label = QLabel("Last update: Never")
-        header_layout.addWidget(self.last_update_label)
-        
-        # Refresh button
-        refresh_btn = QPushButton("🔄 Refresh")
-        refresh_btn.clicked.connect(self.main_window.refresh_data)
-        header_layout.addWidget(refresh_btn)
-        
-        parent_layout.addWidget(header_frame)
-    
-    def create_main_content(self, parent_layout):
-        """Create main dashboard content."""
-        # Create scroll area for main content
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-        
-        # Main content widget
-        content_widget = QWidget()
-        content_layout = QVBoxLayout(content_widget)
-        content_layout.setSpacing(15)
-        
-        # Create summary cards
-        self.create_summary_cards(content_layout)
-        
-        # Create opportunities section
-        self.create_opportunities_section(content_layout)
-        
-        # Create market trends section
-        self.create_market_trends_section(content_layout)
-        
-        scroll_area.setWidget(content_widget)
-        parent_layout.addWidget(scroll_area)
-    
-    def create_summary_cards(self, parent_layout):
-        """Create summary information cards."""
-        cards_frame = QFrame()
-        cards_layout = QGridLayout(cards_frame)
-        cards_layout.setSpacing(10)
-        
-        # Best flip opportunity card
-        self.flip_card = self.create_summary_card(
-            "💰 Best Flip",
-            "No data",
-            "Loading...",
-            QColor(46, 125, 50)  # Green
+
+        stats = QHBoxLayout()
+        stats.addWidget(QLabel("Last update:"))
+        self.lblLastUpdate = QLabel("Loading…")
+        stats.addWidget(self.lblLastUpdate)
+        stats.addStretch()
+        stats.addWidget(QLabel("Records:"))
+        self.lblRecords = QLabel("0")
+        stats.addWidget(self.lblRecords)
+        layout.addLayout(stats)
+
+        self.topTable = QTableWidget(0, 7)
+        self.topTable.setHorizontalHeaderLabels(
+            ["Item", "Route", "Buy", "Sell", "Spread", "ROI%", "Updated"]
         )
-        cards_layout.addWidget(self.flip_card, 0, 0)
-        
-        # Best crafting opportunity card
-        self.crafting_card = self.create_summary_card(
-            "🔨 Best Craft",
-            "No data",
-            "Loading...",
-            QColor(25, 118, 210)  # Blue
-        )
-        cards_layout.addWidget(self.crafting_card, 0, 1)
-        
-        # Market activity card
-        self.activity_card = self.create_summary_card(
-            "📈 Market Activity",
-            "No data",
-            "Loading...",
-            QColor(156, 39, 176)  # Purple
-        )
-        cards_layout.addWidget(self.activity_card, 0, 2)
-        
-        # Data freshness card
-        self.freshness_card = self.create_summary_card(
-            "🕒 Data Age",
-            "No data",
-            "Loading...",
-            QColor(255, 152, 0)  # Orange
-        )
-        cards_layout.addWidget(self.freshness_card, 0, 3)
-        
-        parent_layout.addWidget(cards_frame)
-    
-    def create_summary_card(self, title: str, value: str, subtitle: str, color: QColor) -> QGroupBox:
-        """Create a summary card widget."""
-        card = QGroupBox()
-        card.setFixedHeight(120)
-        card.setStyleSheet(f"""
-            QGroupBox {{
-                border: 2px solid {color.name()};
-                border-radius: 8px;
-                margin-top: 10px;
-                background-color: rgba({color.red()}, {color.green()}, {color.blue()}, 0.1);
-            }}
-        """)
-        
-        layout = QVBoxLayout(card)
-        layout.setContentsMargins(10, 15, 10, 10)
-        
-        # Title
-        title_label = QLabel(title)
-        title_font = QFont()
-        title_font.setBold(True)
-        title_label.setFont(title_font)
-        layout.addWidget(title_label)
-        
-        # Value
-        value_label = QLabel(value)
-        value_font = QFont()
-        value_font.setPointSize(14)
-        value_font.setBold(True)
-        value_label.setFont(value_font)
-        value_label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(value_label)
-        
-        # Subtitle
-        subtitle_label = QLabel(subtitle)
-        subtitle_label.setAlignment(Qt.AlignCenter)
-        subtitle_label.setStyleSheet("color: gray;")
-        layout.addWidget(subtitle_label)
-        
-        # Store labels for updates
-        card.value_label = value_label
-        card.subtitle_label = subtitle_label
-        
-        return card
+        self.topTable.verticalHeader().setVisible(False)
+        self.topTable.setSelectionMode(QTableWidget.NoSelection)
+        layout.addWidget(self.topTable)
+
+    def _setCell(self, row: int, col: int, text: str, tooltip: str | None = None) -> None:
+        item = QTableWidgetItem(text)
+        if tooltip:
+            item.setToolTip(tooltip)
+        item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+        self.topTable.setItem(row, col, item)
 
     # ------------------------------------------------------------------
     # Signal handlers
     # ------------------------------------------------------------------
-    def on_market_data_ready(self, summary: Dict[str, Any]) -> None:
-        """Update dashboard cards when new market data arrives."""
+    def set_loading_state(self, loading: bool) -> None:
+        if loading:
+            self.lblLastUpdate.setText("Loading…")
+            self.topTable.clearContents()
+            self.topTable.setRowCount(0)
+        self.cards.setLoading(loading) if hasattr(self, "cards") else None
 
-        # Stop loading subtitles
-        for card in [self.flip_card, self.crafting_card, self.activity_card, self.freshness_card]:
-            if card.subtitle_label.text() == "Loading...":
-                card.subtitle_label.setText("")
+    def on_market_data_ready(self, summary: dict) -> None:
+        self.set_loading_state(False)
+        ts = summary.get("last_update_utc")
+        if ts:
+            self.lblLastUpdate.setText(f"{rel_age(ts)} ago")
+            self.lblLastUpdate.setToolTip(fmt_tooltip(ts))
+        self.lblRecords.setText(str(summary.get("records", 0)))
 
-        best_flip = summary.get("best_flip")
-        if best_flip:
-            self.flip_card.value_label.setText(str(best_flip))
-        else:
-            self.flip_card.value_label.setText("No data")
-
-        best_craft = summary.get("best_craft")
-        if best_craft:
-            self.crafting_card.value_label.setText(str(best_craft))
-        else:
-            self.crafting_card.value_label.setText("No data")
-
-        activity = summary.get("activity")
-        if activity:
-            self.activity_card.value_label.setText(str(activity))
-        else:
-            self.activity_card.value_label.setText("No data")
-
-        last_update = summary.get("last_update_utc")
-        if last_update:
-            dt = to_utc(last_update)
-            self.last_update_label.setText(f"Last update: {rel_age(dt)}")
-            self.last_update_label.setToolTip(fmt_tooltip(dt))
-
-    
-    def create_opportunities_section(self, parent_layout):
-        """Create opportunities overview section."""
-        opportunities_group = QGroupBox("🎯 Top Opportunities")
-        opportunities_layout = QVBoxLayout(opportunities_group)
-        
-        # Create opportunities table
-        self.opportunities_table = QTableWidget()
-        self.opportunities_table.setColumnCount(6)
-        self.opportunities_table.setHorizontalHeaderLabels([
-            "Type", "Item", "Route", "Profit", "ROI %", "Risk"
-        ])
-        
-        # Configure table
-        header = self.opportunities_table.horizontalHeader()
-        header.setSectionResizeMode(QHeaderView.Stretch)
-        self.opportunities_table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.opportunities_table.setAlternatingRowColors(True)
-        self.opportunities_table.setMaximumHeight(200)
-        
-        opportunities_layout.addWidget(self.opportunities_table)
-        
-        # Add "View All" button
-        view_all_btn = QPushButton("View All Opportunities")
-        view_all_btn.clicked.connect(self.view_all_opportunities)
-        opportunities_layout.addWidget(view_all_btn)
-        
-        parent_layout.addWidget(opportunities_group)
-    
-    def create_market_trends_section(self, parent_layout):
-        """Create market trends section."""
-        trends_group = QGroupBox("📊 Market Trends")
-        trends_layout = QVBoxLayout(trends_group)
-        
-        # Placeholder for market trends
-        trends_label = QLabel("Market trends visualization will be implemented here.")
-        trends_label.setAlignment(Qt.AlignCenter)
-        trends_label.setStyleSheet("color: gray; font-style: italic;")
-        trends_layout.addWidget(trends_label)
-        
-        parent_layout.addWidget(trends_group)
-    
-    def create_footer(self, parent_layout):
-        """Create dashboard footer."""
-        footer_frame = QFrame()
-        footer_frame.setFrameStyle(QFrame.StyledPanel)
-        footer_layout = QHBoxLayout(footer_frame)
-        
-        # Status information
-        self.status_label = QLabel("Ready")
-        footer_layout.addWidget(self.status_label)
-        
-        footer_layout.addStretch()
-        
-        # Progress bar
-        self.progress_bar = QProgressBar()
-        self.progress_bar.setVisible(False)
-        self.progress_bar.setMaximumWidth(200)
-        footer_layout.addWidget(self.progress_bar)
-        
-        parent_layout.addWidget(footer_frame)
-    
-    def init_backend(self):
-        """Initialize backend components."""
-        try:
-            config = self.main_window.get_config()
-            
-            # Initialize flip calculator
-            self.flip_calculator = FlipCalculator(config)
-            
-            # Initialize recipe loader and crafting optimizer
-            self.recipe_loader = RecipeLoader()
-            recipes = self.recipe_loader.load_recipes()
-            
-            if recipes:
-                self.crafting_optimizer = CraftingOptimizer(config, self.recipe_loader)
-                self.logger.info("Backend components initialized successfully")
-            else:
-                self.logger.warning("No recipes loaded, crafting optimizer disabled")
-            
-        except Exception as e:
-            self.logger.error(f"Failed to initialize backend: {e}")
-    
-    def refresh_data(self):
-        """Refresh dashboard data."""
-        self.set_status("Refreshing dashboard data...")
-        self.progress_bar.setVisible(True)
-        self.progress_bar.setRange(0, 0)  # Indeterminate
-        
-        try:
-            # Get fresh market data
-            api_client = self.main_window.get_api_client()
-            if not api_client:
-                raise Exception("API client not available")
-            
-            # Get sample data for dashboard
-            sample_items = ['T4_BAG', 'T5_BAG', 'T4_SWORD', 'T5_SWORD']
-            sample_cities = ['Caerleon', 'Martlock', 'Lymhurst']
-            
-            prices = api_client.get_current_prices(sample_items, sample_cities, [1])
-            
-            if prices:
-                # Update opportunities
-                self.update_opportunities(prices)
-                
-                # Update summary cards
-                self.update_summary_cards(prices)
-                
-                # Update last update time
-                self.last_update = datetime.now()
-                self.last_update_label.setText(f"Last update: {self.last_update.strftime('%H:%M:%S')}")
-                
-                self.set_status("Dashboard updated successfully")
-            else:
-                self.set_status("No market data available")
-            
-        except Exception as e:
-            self.logger.error(f"Dashboard refresh failed: {e}")
-            self.set_status(f"Refresh failed: {e}")
-        
-        finally:
-            self.progress_bar.setVisible(False)
-    
-    def update_opportunities(self, prices: List[Dict[str, Any]]):
-        """Update opportunities table."""
-        try:
-            if not self.flip_calculator:
-                return
-            
-            # Group prices by item
-            prices_by_item = {}
-            for price in prices:
-                item_id = price['item_id']
-                if item_id not in prices_by_item:
-                    prices_by_item[item_id] = []
-                prices_by_item[item_id].append(price)
-            
-            # Calculate flip opportunities
-            opportunities = self.flip_calculator.calculate_flip_opportunities(prices_by_item)
-            
-            # Sort by profit and take top 10
-            opportunities.sort(key=lambda x: x.profit_per_unit, reverse=True)
-            top_opportunities = opportunities[:10]
-            
-            # Update table
-            self.opportunities_table.setRowCount(len(top_opportunities))
-            
-            for row, opp in enumerate(top_opportunities):
-                # Type
-                type_item = QTableWidgetItem("Flip")
-                self.opportunities_table.setItem(row, 0, type_item)
-                
-                # Item
-                item_item = QTableWidgetItem(opp.item_id)
-                self.opportunities_table.setItem(row, 1, item_item)
-                
-                # Route
-                route_item = QTableWidgetItem(f"{opp.source_city} → {opp.destination_city}")
-                self.opportunities_table.setItem(row, 2, route_item)
-                
-                # Profit
-                profit_item = QTableWidgetItem(f"{opp.profit_per_unit:,.0f}")
-                self.opportunities_table.setItem(row, 3, profit_item)
-                
-                # ROI
-                roi_item = QTableWidgetItem(f"{opp.roi_percent:.1f}%")
-                self.opportunities_table.setItem(row, 4, roi_item)
-                
-                # Risk
-                risk_item = QTableWidgetItem(opp.risk_level.title())
-                if opp.risk_level == 'low':
-                    risk_item.setBackground(QColor(200, 255, 200))
-                elif opp.risk_level == 'medium':
-                    risk_item.setBackground(QColor(255, 255, 200))
-                else:
-                    risk_item.setBackground(QColor(255, 200, 200))
-                self.opportunities_table.setItem(row, 5, risk_item)
-            
-            self.cached_opportunities = top_opportunities
-            
-        except Exception as e:
-            self.logger.error(f"Failed to update opportunities: {e}")
-    
-    def update_summary_cards(self, prices: List[Dict[str, Any]]):
-        """Update summary cards with latest data."""
-        try:
-            # Best flip opportunity
-            if self.cached_opportunities:
-                best_flip = self.cached_opportunities[0]
-                self.flip_card.value_label.setText(f"{best_flip.profit_per_unit:,.0f}")
-                self.flip_card.subtitle_label.setText(f"{best_flip.item_id} ({best_flip.roi_percent:.1f}% ROI)")
-            else:
-                self.flip_card.value_label.setText("No data")
-                self.flip_card.subtitle_label.setText("No opportunities found")
-            
-            # Market activity (number of recent price updates)
-            recent_prices = [p for p in prices if 
-                           (datetime.utcnow() - p['observed_at_utc']).total_seconds() < 3600]
-            self.activity_card.value_label.setText(str(len(recent_prices)))
-            self.activity_card.subtitle_label.setText(f"Updates in last hour")
-            
-            # Data freshness
-            if prices:
-                latest_price = max(prices, key=lambda x: x['observed_at_utc'])
-                age_hours = (datetime.utcnow() - latest_price['observed_at_utc']).total_seconds() / 3600
-                self.freshness_card.value_label.setText(f"{age_hours:.1f}h")
-                self.freshness_card.subtitle_label.setText("Latest data age")
-            else:
-                self.freshness_card.value_label.setText("No data")
-                self.freshness_card.subtitle_label.setText("No price data")
-            
-            # Crafting opportunities (placeholder)
-            self.crafting_card.value_label.setText("Coming soon")
-            self.crafting_card.subtitle_label.setText("Crafting analysis")
-            
-        except Exception as e:
-            self.logger.error(f"Failed to update summary cards: {e}")
-    
-    def view_all_opportunities(self):
-        """Switch to flip finder tab to view all opportunities."""
-        main_window = self.main_window
-        flip_finder_widget = main_window.flip_finder_widget
-        main_window.tab_widget.setCurrentWidget(flip_finder_widget)
-        
-        # Trigger refresh in flip finder if it has cached data
-        if hasattr(flip_finder_widget, 'set_opportunities') and self.cached_opportunities:
-            flip_finder_widget.set_opportunities(self.cached_opportunities)
-    
-    def set_status(self, message: str):
-        """Set status message."""
-        self.status_label.setText(message)
-        self.logger.debug(f"Dashboard status: {message}")
-    
-    def clear_cache(self):
-        """Clear cached data."""
-        self.cached_opportunities = []
-        self.cached_crafting_plans = []
-        self.last_update = None
-        
-        # Clear table
-        self.opportunities_table.setRowCount(0)
-        
-        # Reset summary cards
-        for card in [self.flip_card, self.crafting_card, self.activity_card, self.freshness_card]:
-            card.value_label.setText("No data")
-            card.subtitle_label.setText("Loading...")
-        
-        self.last_update_label.setText("Last update: Never")
-        self.set_status("Cache cleared")
-
+        tops = summary.get("top_opportunities") or []
+        self.topTable.clearContents()
+        self.topTable.setRowCount(len(tops))
+        for i, t in enumerate(tops):
+            self._setCell(i, 0, t["item"])
+            self._setCell(i, 1, f'{t["buy_city"]} \u2192 {t["sell_city"]}')
+            self._setCell(i, 2, str(t["buy_price"]))
+            self._setCell(i, 3, str(t["sell_price"]))
+            self._setCell(i, 4, f'{t["spread"]}')
+            self._setCell(i, 5, f'{t["roi_pct"]:.1f}%')
+            self._setCell(
+                i,
+                6,
+                rel_age(t["updated_dt"]),
+                tooltip=fmt_tooltip(t["updated_dt"]),
+            )
+        if not tops:
+            self.topTable.setRowCount(1)
+            self._setCell(
+                0,
+                0,
+                "No opportunities",
+                tooltip="Try widening cities/qualities or lower min ROI",
+            )

--- a/gui/widgets/flip_finder.py
+++ b/gui/widgets/flip_finder.py
@@ -604,7 +604,7 @@ Notes:
             return
         
         # This would open a file dialog and export to CSV/Excel
-        self.set_status("Export feature coming soon!")
+        self.set_status("Export feature not yet implemented")
     
     def refresh_data(self):
         """Refresh data (called from main window)."""

--- a/gui/widgets/market_prices.py
+++ b/gui/widgets/market_prices.py
@@ -150,7 +150,11 @@ class MarketPricesWidget(QWidget):
             self.table.setItem(row_index, 4, QTableWidgetItem(str(row.get("sell_city"))))
             self.table.setItem(row_index, 5, QTableWidgetItem(str(row.get("spread"))))
             roi = row.get("roi_pct")
-            self.table.setItem(row_index, 6, QTableWidgetItem(f"{roi:.2f}" if roi is not None else ""))
+            self.table.setItem(
+                row_index,
+                6,
+                QTableWidgetItem(f"{roi:.1f}" if roi is not None else ""),
+            )
 
             dt = row.get("updated_dt")
             item = QTableWidgetItem("")

--- a/services/market_prices.py
+++ b/services/market_prices.py
@@ -12,7 +12,8 @@ from datasources.http import get_shared_session
 from datasources.aodp_url import base_for, build_prices_request, DEFAULT_CITIES
 from utils.params import qualities_to_csv, cities_to_list
 from utils.items import parse_items, items_catalog_codes
-from utils.timefmt import to_utc
+from utils.timefmt import to_utc, now_utc_iso
+from core.signals import signals
 
 log = logging.getLogger(__name__)
 
@@ -132,7 +133,42 @@ def normalize_and_dedupe(rows: List[Dict]) -> List[Dict]:
                 "sell_city": city if sell else None,
                 "updated_dt": best_dt or to_utc("1970-01-01T00:00:00Z"),
             }
-    return list(out.values())
+    norm = list(out.values())
+
+    summary = {
+        "last_update_utc": now_utc_iso(),
+        "records": len(norm),
+        "top_opportunities": top_opportunities(norm, limit=20),
+    }
+    signals.market_data_ready.emit(summary)
+    return norm
 
 
-__all__ = ["fetch_prices", "normalize_and_dedupe", "DEFAULT_CITIES", "DEFAULT_QUALITIES"]
+def top_opportunities(rows: list[dict], limit: int = 20) -> list[dict]:
+    """Compute top arbitrage opportunities from normalized rows."""
+    cands: list[dict] = []
+    for r in rows:
+        if (r.get("buy_price_max", 0) > 0) and (r.get("sell_price_min", 0) > 0) and r.get("spread", 0) > 0:
+            cands.append(
+                {
+                    "item": r["item_id"],
+                    "buy_city": r.get("buy_city") or r.get("city"),
+                    "buy_price": r["buy_price_max"],
+                    "sell_city": r.get("sell_city") or r.get("city"),
+                    "sell_price": r["sell_price_min"],
+                    "spread": r["spread"],
+                    "roi_pct": r["roi_pct"],
+                    "updated_dt": r["updated_dt"],
+                }
+            )
+    cands.sort(key=lambda x: (x["roi_pct"], x["spread"]), reverse=True)
+    return cands[:limit]
+
+
+__all__ = [
+    "fetch_prices",
+    "normalize_and_dedupe",
+    "DEFAULT_CITIES",
+    "DEFAULT_QUALITIES",
+    "top_opportunities",
+]

--- a/tests/test_dashboard_updates.py
+++ b/tests/test_dashboard_updates.py
@@ -1,0 +1,45 @@
+import os, sys, pathlib
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_OPENGL", "software")
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from datetime import datetime
+import pytest
+try:
+    from PySide6.QtWidgets import QApplication
+except Exception:  # pragma: no cover
+    pytest.skip("PySide6 not available", allow_module_level=True)
+
+from core.signals import signals
+from gui.widgets.dashboard import DashboardWidget
+from utils.timefmt import now_utc_iso
+
+
+def test_dashboard_updates():
+    app = QApplication.instance() or QApplication([])
+    w = DashboardWidget()
+    assert w.lblLastUpdate.text() == "Loading…"
+
+    dt = datetime.utcnow()
+    summary = {
+        "last_update_utc": now_utc_iso(),
+        "records": 5,
+        "top_opportunities": [
+            {
+                "item": "T4_BAG",
+                "buy_city": "Lymhurst",
+                "buy_price": 100,
+                "sell_city": "Martlock",
+                "sell_price": 150,
+                "spread": 50,
+                "roi_pct": 50.0,
+                "updated_dt": dt,
+            }
+        ],
+    }
+    signals.market_data_ready.emit(summary)
+    app.processEvents()
+
+    assert w.lblRecords.text() == "5"
+    assert w.topTable.rowCount() == 1
+    assert w.lblLastUpdate.text().endswith("ago")

--- a/tests/test_data_manager_api_status.py
+++ b/tests/test_data_manager_api_status.py
@@ -1,0 +1,50 @@
+import os, sys, pathlib
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_OPENGL", "software")
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+try:
+    from PySide6.QtWidgets import QApplication
+except Exception:  # pragma: no cover
+    pytest.skip("PySide6 not available", allow_module_level=True)
+
+import core.health as health
+from core.health import store
+from gui.widgets.data_manager import DataManagerWidget
+
+
+class DummyMain:
+    def get_db_manager(self):
+        return None
+
+    def get_api_client(self):
+        return None
+
+    def refresh_data(self):
+        pass
+
+    def set_status(self, msg):
+        pass
+
+
+def test_api_status_tile(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+
+    def online_ping(server):
+        store.set_online(True)
+        return True
+
+    monkeypatch.setattr(health, "ping_aodp", online_ping)
+    w = DataManagerWidget(DummyMain())
+    assert w.lblApiStatus.text() == "Online"
+    assert w.api_status_card.value_label.text().startswith("🟢")
+
+    def offline_ping(server):
+        store.set_online(False)
+        return False
+
+    monkeypatch.setattr(health, "ping_aodp", offline_ping)
+    w.refreshApiStatus()
+    assert w.lblApiStatus.text() == "Offline"
+    assert w.api_status_card.value_label.text().startswith("🔴")

--- a/tests/test_health_store.py
+++ b/tests/test_health_store.py
@@ -7,6 +7,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import types
 from core.health import store, ping_aodp
 import datasources.aodp_url as aurl
+import core.health as health_module
 
 
 class DummyResp:
@@ -29,14 +30,15 @@ def test_health_requires_three_failures(monkeypatch):
         return DummyResp(statuses.pop(0))
 
     session = types.SimpleNamespace(get=fake_get)
+    monkeypatch.setattr(health_module, "get_shared_session", lambda: session)
     monkeypatch.setattr(aurl, "base_for", lambda s: s)
     store.aodp_online = True
     store._fails = 0
-    ping_aodp("west", session)
+    ping_aodp("west")
     assert store.aodp_online
-    ping_aodp("west", session)
+    ping_aodp("west")
     assert store.aodp_online
-    ping_aodp("west", session)
+    ping_aodp("west")
     assert not store.aodp_online
 
 
@@ -45,10 +47,11 @@ def test_health_429_is_online(monkeypatch):
         return DummyResp(429)
 
     session = types.SimpleNamespace(get=fake_get)
+    monkeypatch.setattr(health_module, "get_shared_session", lambda: session)
     monkeypatch.setattr(aurl, "base_for", lambda s: s)
     store.aodp_online = False
     store._fails = 5
-    ping_aodp("west", session)
+    ping_aodp("west")
     assert store.aodp_online and store._fails == 0
 
 
@@ -59,11 +62,12 @@ def test_success_resets_failures(monkeypatch):
         return DummyResp(statuses.pop(0))
 
     session = types.SimpleNamespace(get=fake_get)
+    monkeypatch.setattr(health_module, "get_shared_session", lambda: session)
     monkeypatch.setattr(aurl, "base_for", lambda s: s)
     store.aodp_online = True
     store._fails = 0
-    ping_aodp("west", session)
+    ping_aodp("west")
     assert store._fails == 1
-    ping_aodp("west", session)
+    ping_aodp("west")
     assert store.aodp_online and store._fails == 0
 

--- a/utils/timefmt.py
+++ b/utils/timefmt.py
@@ -55,4 +55,9 @@ def fmt_tooltip(utc_dt: datetime) -> str:
     return utc_dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
 
 
-__all__ = ["to_utc", "rel_age", "fmt_tooltip"]
+def now_utc_iso() -> str:
+    """Return current UTC time as ISO8601 string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = ["to_utc", "rel_age", "fmt_tooltip", "now_utc_iso"]


### PR DESCRIPTION
## Summary
- emit top-opportunity summaries after price refreshes and signal the dashboard
- replace dashboard and data manager placeholders with real market stats and API health status
- add now_utc_iso helper and wire ROI/updated fields to real data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b3ddd5ec8330a56689ac9e808b49