### PR TITLE
Refactor health checks and clean market refresh workflow

### DIFF
--- a/datasources/aodp.py
+++ b/datasources/aodp.py
@@ -346,28 +346,10 @@ class AODPClient:
             return False
     
     def get_server_status(self) -> Dict[str, Any]:
-        """Get API server status information."""
-        try:
-            # Make a simple request to check server status
-            response = self.session.get(
-                self.base_url,
-                timeout=10,
-            )
+        from core.health import ping_aodp
 
-            online = response.status_code == 200
-            return {
-                'status': 'online' if online else 'error',
-                'status_code': response.status_code,
-                'response_time_ms': response.elapsed.total_seconds() * 1000,
-                'base_url': self.base_url
-            }
-
-        except Exception as e:
-            return {
-                'status': 'offline',
-                'error': str(e),
-                'base_url': self.base_url
-            }
+        ok = ping_aodp(self.server or "europe")
+        return {"online": ok}
     
     def close(self):
         """Close the HTTP session."""

--- a/gui/widgets/data_manager.py
+++ b/gui/widgets/data_manager.py
@@ -17,7 +17,6 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QFont, QColor
 from core.signals import signals
-from utils.timefmt import fmt_tooltip
 
 
 class DataManagerWidget(QWidget):
@@ -319,7 +318,7 @@ class DataManagerWidget(QWidget):
         else:
             self.lblApiStatus.setText("Offline")
             self.api_status_card.value_label.setText("🔴 Offline")
-            self.api_status_card.subtitle_label.setText("Connection Error")
+            self.api_status_card.subtitle_label.setText("Check network / rate limits")
         self.update_sources_table()
 
     def refreshApiStatus(self):

--- a/tests/test_data_manager_api_status.py
+++ b/tests/test_data_manager_api_status.py
@@ -37,8 +37,8 @@ def test_api_status_tile(monkeypatch):
 
     monkeypatch.setattr(health, "ping_aodp", online_ping)
     w = DataManagerWidget(DummyMain())
-    assert w.lblApiStatus.text() == "Online"
-    assert w.api_status_card.value_label.text().startswith("🟢")
+    assert w.api_status_card.value_label.text() == "🟢 Online"
+    assert w.api_status_card.subtitle_label.text() == "AODP Connection"
 
     def offline_ping(server):
         store.set_online(False)
@@ -46,5 +46,5 @@ def test_api_status_tile(monkeypatch):
 
     monkeypatch.setattr(health, "ping_aodp", offline_ping)
     w.refreshApiStatus()
-    assert w.lblApiStatus.text() == "Offline"
-    assert w.api_status_card.value_label.text().startswith("🔴")
+    assert w.api_status_card.value_label.text() == "🔴 Offline"
+    assert w.api_status_card.subtitle_label.text() == "Check network / rate limits"


### PR DESCRIPTION
## Summary
- Use JSON-based AODP ping in Data Manager and simplify status messaging
- Drop obsolete market prices loader and emit market data events only from service layer
- Delegate AODPClient.get_server_status to core health ping

## Testing
- `pytest tests/test_data_manager_api_status.py tests/test_dashboard_updates.py -q` *(skipped: PySide6 not available)*
- `pytest tests -q` *(errors: ModuleNotFoundError: logging_config)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ba34f13483309bcfeabd6dcafca5