### PR TITLE
feat: add items browser tab

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -5,6 +5,7 @@ class AppSignals(QObject):
     """Central application-wide signals bus."""
 
     market_data_ready = Signal(dict)
+    market_rows_updated = Signal(list)
     health_changed = Signal(object)
 
 

--- a/datasources/aodp.py
+++ b/datasources/aodp.py
@@ -365,10 +365,10 @@ def refresh_prices(server: str, cities: list[str], qualities, items_text: str = 
     behaviour.
     """
 
-    from services.market_prices import fetch_prices, normalize_and_dedupe
+    from services.market_prices import fetch_prices
     from datasources.http import get_shared_session
 
-    rows = fetch_prices(
+    norm = fetch_prices(
         server=server,
         items_edit_text=items_text,
         cities_sel=",".join(cities) if cities else "",
@@ -378,6 +378,5 @@ def refresh_prices(server: str, cities: list[str], qualities, items_text: str = 
         on_progress=on_progress,
         cancel=should_cancel,
     )
-    norm = normalize_and_dedupe(rows)
-    return {"items": len(norm), "records": len(rows)}
+    return {"items": len(norm), "records": len(norm)}
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -27,6 +27,7 @@ from gui.widgets.crafting_optimizer import CraftingOptimizerWidget
 from gui.widgets.settings import SettingsWidget
 from gui.widgets.data_manager import DataManagerWidget
 from gui.widgets.market_prices import MarketPricesWidget
+from gui.widgets.items_browser import ItemsBrowser
 
 # Import backend components
 from engine.config import ConfigManager
@@ -99,7 +100,11 @@ class MainWindow(QMainWindow):
         # Market Prices tab
         self.market_prices_widget = MarketPricesWidget(self)
         self.tab_widget.addTab(self.market_prices_widget, "💹 Prices")
-        
+
+        # Items tab
+        self.items_browser = ItemsBrowser(self)
+        self.tab_widget.addTab(self.items_browser, "📦 Items")
+
         # Settings tab
         self.settings_widget = SettingsWidget(self)
         self.tab_widget.addTab(self.settings_widget, "⚙️ Settings")

--- a/gui/widgets/items_browser.py
+++ b/gui/widgets/items_browser.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QComboBox, QLabel, QPushButton,
+    QTableView, QFileDialog, QSpinBox
+)
+from core.signals import signals
+from utils.timefmt import rel_age, fmt_tooltip
+
+COLUMNS = [
+    ("Item", "item_id"),
+    ("City", "city"),
+    ("Quality", "quality"),
+    ("Buy (max)", "buy_price_max"),
+    ("Sell (min)", "sell_price_min"),
+    ("Spread", "spread"),
+    ("ROI %", "roi_pct"),
+    ("Updated", "updated_dt"),  # render rel_age + tooltip
+]
+
+DEFAULT_CITIES = ["All Cities","Bridgewatch","Caerleon","Fort Sterling","Lymhurst","Martlock","Thetford","Black Market"]
+QUALS = ["All","1","2","3","4","5"]
+
+
+class ItemsModel(QAbstractTableModel):
+    def __init__(self, rows: list[dict] | None = None):
+        super().__init__()
+        self.rows = rows or []
+
+    def rowCount(self, parent=QModelIndex()): return len(self.rows)
+    def columnCount(self, parent=QModelIndex()): return len(COLUMNS)
+
+    def data(self, idx: QModelIndex, role=Qt.DisplayRole):
+        if not idx.isValid(): return None
+        row = self.rows[idx.row()]
+        header, key = COLUMNS[idx.column()]
+        if role == Qt.DisplayRole:
+            if key == "updated_dt":
+                return rel_age(row.get("updated_dt"))
+            val = row.get(key)
+            if key == "roi_pct" and isinstance(val, (int, float)):
+                return f"{val:.1f}"
+            return "" if val is None else str(val)
+        if role == Qt.ToolTipRole and key == "updated_dt":
+            return fmt_tooltip(row.get("updated_dt"))
+        return None
+
+    def headerData(self, section, orientation, role=Qt.DisplayRole):
+        if role == Qt.DisplayRole and orientation == Qt.Horizontal:
+            return COLUMNS[section][0]
+        return super().headerData(section, orientation, role)
+
+    def setRows(self, rows: list[dict]):
+        self.beginResetModel()
+        self.rows = rows
+        self.endResetModel()
+
+
+class ItemsBrowser(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.rows_all: list[dict] = []
+        self.rows_filtered: list[dict] = []
+        self.page = 1
+        self.page_size = 100
+
+        # Controls
+        top = QHBoxLayout()
+        self.search = QLineEdit()
+        self.search.setPlaceholderText("Filter by Item ID (e.g., T4_SWORD)")
+        self.cboCity = QComboBox(); self.cboCity.addItems(DEFAULT_CITIES)
+        self.cboQual = QComboBox(); self.cboQual.addItems(QUALS)
+        self.lblCounts = QLabel("0 rows")
+        self.btnPrev = QPushButton("◀ Prev")
+        self.btnNext = QPushButton("Next ▶")
+        self.spnPage = QSpinBox(); self.spnPage.setRange(1, 1)
+        self.cboPageSize = QComboBox(); self.cboPageSize.addItems(["50","100","200","500"]); self.cboPageSize.setCurrentText("100")
+        self.btnExport = QPushButton("Export CSV (page)")
+
+        top.addWidget(self.search, 2)
+        top.addWidget(QLabel("City:")); top.addWidget(self.cboCity)
+        top.addWidget(QLabel("Quality:")); top.addWidget(self.cboQual)
+        top.addWidget(QLabel("Page:")); top.addWidget(self.spnPage)
+        top.addWidget(QLabel("Size:")); top.addWidget(self.cboPageSize)
+        top.addWidget(self.btnPrev); top.addWidget(self.btnNext)
+        top.addWidget(self.btnExport)
+        top.addStretch()
+        top.addWidget(self.lblCounts)
+
+        # Table
+        self.table = QTableView()
+        self.model = ItemsModel([])
+        self.table.setModel(self.model)
+        self.table.setSortingEnabled(True)
+
+        lay = QVBoxLayout(self)
+        lay.addLayout(top)
+        lay.addWidget(self.table)
+
+        # Signals (UI)
+        self.search.textChanged.connect(self._apply_filters)
+        self.cboCity.currentIndexChanged.connect(self._apply_filters)
+        self.cboQual.currentIndexChanged.connect(self._apply_filters)
+        self.cboPageSize.currentTextChanged.connect(self._change_page_size)
+        self.btnPrev.clicked.connect(self._prev)
+        self.btnNext.clicked.connect(self._next)
+        self.spnPage.valueChanged.connect(self._goto_page)
+        self.btnExport.clicked.connect(self._export_csv)
+
+        # App signal: new rows available
+        signals.market_rows_updated.connect(self.on_rows_updated)
+
+    # --- data flow ---
+    def on_rows_updated(self, rows: list[dict]):
+        self.rows_all = rows or []
+        self.page = 1
+        self._apply_filters()
+
+    # --- filtering/paging ---
+    def _apply_filters(self):
+        text = (self.search.text() or "").strip().upper()
+        city = self.cboCity.currentText()
+        qual = self.cboQual.currentText()
+
+        rf = self.rows_all
+        if text:
+            rf = [r for r in rf if text in (r.get("item_id","" ) or "")]
+        if city and city != "All Cities":
+            rf = [r for r in rf if r.get("city") == city]
+        if qual and qual != "All":
+            try:
+                qn = int(qual)
+                rf = [r for r in rf if int(r.get("quality") or 0) == qn]
+            except:
+                pass
+
+        self.rows_filtered = rf
+        # recompute pages
+        total_pages = max(1, (len(self.rows_filtered) + self.page_size - 1) // self.page_size)
+        self.spnPage.blockSignals(True)
+        self.spnPage.setMaximum(total_pages)
+        if self.page > total_pages:
+            self.page = total_pages
+        self.spnPage.setValue(self.page)
+        self.spnPage.blockSignals(False)
+        self._refresh_page()
+
+    def _change_page_size(self, txt):
+        try:
+            self.page_size = int(txt)
+        except:
+            self.page_size = 100
+        self.page = 1
+        self._apply_filters()
+
+    def _slice_for_page(self):
+        start = (self.page - 1) * self.page_size
+        end = start + self.page_size
+        return start, end
+
+    def _refresh_page(self):
+        start, end = self._slice_for_page()
+        page_rows = self.rows_filtered[start:end]
+        self.model.setRows(page_rows)
+
+        # counts
+        total = len(self.rows_filtered)
+        unique_items = len({r.get("item_id") for r in self.rows_filtered})
+        if total == 0:
+            rng = "0–0"
+            total_pages = 1
+        else:
+            rng = f"{start+1}–{min(end,total)}"
+            total_pages = max(1, (total + self.page_size - 1) // self.page_size)
+        self.lblCounts.setText(f"Showing {rng} of {total} rows · Unique items: {unique_items} · Page {self.page}/{total_pages}")
+
+        # nav buttons
+        self.btnPrev.setEnabled(self.page > 1)
+        self.btnNext.setEnabled(self.page < total_pages)
+
+    def _prev(self):
+        if self.page > 1:
+            self.page -= 1
+            self._refresh_page()
+
+    def _next(self):
+        total_pages = self.spnPage.maximum()
+        if self.page < total_pages:
+            self.page += 1
+            self._refresh_page()
+
+    def _goto_page(self, val: int):
+        self.page = max(1, min(val, self.spnPage.maximum()))
+        self._refresh_page()
+
+    # --- export ---
+    def _export_csv(self):
+        import csv
+        path, _ = QFileDialog.getSaveFileName(self, "Export current page to CSV", "items_page.csv", "CSV Files (*.csv)")
+        if not path:
+            return
+        start, end = self._slice_for_page()
+        rows = self.rows_filtered[start:end]
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow([c[0] for c in COLUMNS])
+            for r in rows:
+                out = []
+                for header, key in COLUMNS:
+                    if key == "updated_dt":
+                        out.append(fmt_tooltip(r.get(key)))
+                    elif key == "roi_pct":
+                        val = r.get(key) or 0
+                        out.append(f"{val:.1f}")
+                    else:
+                        out.append(r.get(key, ""))
+                w.writerow(out)

--- a/services/market_prices.py
+++ b/services/market_prices.py
@@ -69,8 +69,10 @@ def fetch_prices(
             if cancel(): break
             results.extend(fut.result())
             if on_progress: on_progress(int(idx/len(chunks)*100), f"Fetched {idx}/{len(chunks)}")
-
-    return results
+    norm = normalize_and_dedupe(results)
+    signals.market_rows_updated.emit(norm)
+    emit_summary(norm)
+    return norm
 
 
 def normalize_and_dedupe(rows: List[Dict]) -> List[Dict]:


### PR DESCRIPTION
## Summary
- broadcast normalized market rows to consumers via new `market_rows_updated` signal
- add Items browser tab with filtering, pagination, counts, and CSV export
- normalize and emit rows during fetch, wiring new tab into refresh workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c4ba50f88330a9e7c763ae39de7c