### PR TITLE
Fix fetch_all wiring and normalize selection inputs

### DIFF
--- a/datasources/aodp.py
+++ b/datasources/aodp.py
@@ -373,6 +373,7 @@ def refresh_prices(server: str, cities: list[str], qualities, items_text: str = 
         items_edit_text=items_text,
         cities_sel=",".join(cities) if cities else "",
         qual_sel=",".join(map(str, qualities)) if qualities else "",
+        fetch_all=getattr(settings, "fetch_all_items", False),
         session=get_shared_session(),
         settings=settings,
         on_progress=on_progress,

--- a/gui/threads.py
+++ b/gui/threads.py
@@ -33,15 +33,17 @@ class RefreshWorker(QObject):
             from core.health import mark_online_on_data_success
 
             server = self.params.get("server")
-            cities = self.params.get("cities") or []
-            qualities = self.params.get("qualities") or []
+            cities_sel = self.params.get("cities", "")
+            qual_sel = self.params.get("qualities", "")
+            fetch_all = self.params.get("fetch_all", False)
             items_text = self.itemsEdit.text() if hasattr(self, "itemsEdit") else ""
 
             norm = fetch_prices(
                 server=server,
                 items_edit_text=items_text,
-                cities_sel=",".join(cities) if cities else "",
-                qual_sel=",".join(map(str, qualities)) if qualities else "",
+                cities_sel=cities_sel,
+                qual_sel=qual_sel,
+                fetch_all=fetch_all,
                 session=get_shared_session(),
                 settings=self.settings,
                 on_progress=lambda p, m: self.progress.emit(p, m),

--- a/gui/widgets/flip_finder.py
+++ b/gui/widgets/flip_finder.py
@@ -413,21 +413,19 @@ class FlipFinderWidget(QWidget):
         
         # Items
         cfg = self.main_window.get_config()
+        fetch_all = bool(cfg.get('fetch_all_items', False))
         raw = self.items_edit.text()
         typed = parse_items(raw)
-        if not typed and cfg.get('fetch_all_items', False):
-            items = list(items_catalog_codes())
-        else:
-            items = typed
+        catalog = list(items_catalog_codes())
+        items = catalog if (not typed and fetch_all) else typed
         self.logger.info(
-            "Item selection: typed=%d fetch_all=%s final=%d",
-            len(typed),
-            cfg.get('fetch_all_items', False),
-            len(items),
+            "Item selection: catalog=%d typed=%d fetch_all=%s -> final=%d",
+            len(catalog), len(typed), fetch_all, len(items),
         )
         self.logger.debug("Items(head 12): %s", items[:12])
         if items:
             params['items'] = items
+        params['fetch_all'] = fetch_all
         
         # Cities
         cities_selection = self.cities_combo.currentText()

--- a/services/market_prices.py
+++ b/services/market_prices.py
@@ -34,7 +34,12 @@ def fetch_prices(
     sess = session or get_shared_session()
     typed = parse_items(items_edit_text)
     use_all = fetch_all if fetch_all is not None else bool(getattr(settings, "fetch_all_items", False))
-    items = list(items_catalog_codes()) if (not typed and use_all) else typed
+    catalog = list(items_catalog_codes())
+    items = catalog if (not typed and use_all) else typed
+    log.info(
+        "Item selection: catalog=%d typed=%d fetch_all=%s -> final=%d",
+        len(catalog), len(typed), use_all, len(items),
+    )
     if not items:
         log.info("No items to request (typed=%d, fetch_all=%s).", len(typed), use_all)
         return []

--- a/utils/params.py
+++ b/utils/params.py
@@ -1,6 +1,9 @@
 import re
 
 def qualities_to_csv(selection) -> str:
+    if isinstance(selection, (list, tuple)):
+        nums = [str(int(x)) for x in selection if str(x).isdigit()]
+        return ",".join(nums) if nums else "1,2,3,4,5"
     s = (selection or "").strip().lower()
     if not s or s in ("all", "all qualities"):
         return "1,2,3,4,5"
@@ -11,6 +14,9 @@ def qualities_to_csv(selection) -> str:
     return ",".join([p for p in s.replace(" ", "").split(",") if p.isdigit()]) or "1,2,3,4,5"
 
 def cities_to_list(selection, default_all: list[str]) -> list[str]:
+    # Accept list or CSV string; blank/All -> default_all
+    if isinstance(selection, (list, tuple)):
+        return list(selection) if selection else list(default_all)
     if not selection or str(selection).strip().lower() in ("all", "all cities"):
         return list(default_all)
     return [c.strip() for c in str(selection).split(",") if c.strip()]


### PR DESCRIPTION
## Summary
- pass `fetch_all` and normalized city/quality selectors from the UI to the price fetcher
- make selector mappers tolerant of lists or blank inputs
- add diagnostics and pre-flight guards to avoid empty refreshes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c9f1ce9c83308e576805ca0843c0