### PR TITLE
Improve AODP price fetching robustness

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -145,6 +145,7 @@ class ConfigManager:
             },
             'premium_enabled': True,
             'fetch_all_items': True,
+            'items_per_request': 150,
             'risk': {
                 'caerleon_high_risk': True
             },

--- a/gui/widgets/settings.py
+++ b/gui/widgets/settings.py
@@ -110,7 +110,7 @@ class SettingsWidget(QWidget):
         # Chunk size
         api_layout.addWidget(QLabel("Items per Request:"), row, 0)
         self.chunk_size_spin = QSpinBox()
-        self.chunk_size_spin.setRange(1, 100)
+        self.chunk_size_spin.setRange(1, 300)
         api_layout.addWidget(self.chunk_size_spin, row, 1)
         row += 1
         
@@ -333,7 +333,10 @@ class SettingsWidget(QWidget):
             self.api_url_edit.setText(aodp_config.get('base_url', ''))
             self.rate_delay_spin.setValue(aodp_config.get('rate_delay_seconds', 1.0))
             self.timeout_spin.setValue(aodp_config.get('timeout_seconds', 30))
-            self.chunk_size_spin.setValue(aodp_config.get('chunk_size', 40))
+            chunk_val = self.config.get('items_per_request')
+            if chunk_val is None:
+                chunk_val = aodp_config.get('chunk_size', 150)
+            self.chunk_size_spin.setValue(chunk_val)
 
             # Trading settings
             self.premium_check.setChecked(self.config.get('premium_enabled', True))
@@ -387,7 +390,9 @@ class SettingsWidget(QWidget):
             config['aodp']['base_url'] = self.api_url_edit.text()
             config['aodp']['rate_delay_seconds'] = self.rate_delay_spin.value()
             config['aodp']['timeout_seconds'] = self.timeout_spin.value()
-            config['aodp']['chunk_size'] = self.chunk_size_spin.value()
+            chunk_val = self.chunk_size_spin.value()
+            config['aodp']['chunk_size'] = chunk_val
+            config['items_per_request'] = chunk_val
             
             # Trading settings
             config['premium_enabled'] = self.premium_check.isChecked()

--- a/tests/test_url_chunking.py
+++ b/tests/test_url_chunking.py
@@ -1,0 +1,39 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import types
+
+from services.market_prices import _chunk_by_len_and_count, _estimate_url_len, fetch_prices
+
+class DummyResp:
+    def __init__(self, status, data=None):
+        self.status_code = status
+        self._data = data or []
+    def raise_for_status(self):
+        if self.status_code >= 400 and self.status_code not in (414, 429):
+            raise Exception("error")
+    def json(self):
+        return self._data
+
+
+def test_chunk_by_len_and_count_respects_url():
+    base = "https://example.com"
+    cities_csv = "Caerleon"
+    quals_csv = "1"
+    items = ["X" * 500, "Y" * 500]
+    chunks = _chunk_by_len_and_count(items, base, cities_csv, quals_csv, 10, max_url=1000)
+    assert all(_estimate_url_len(base, c, cities_csv, quals_csv) <= 1000 for c in chunks)
+
+
+def test_auto_split_on_414(monkeypatch):
+    responses = [
+        DummyResp(414),
+        DummyResp(200, [{"item_id": "A", "city": "Caerleon", "sell_price_min": 1, "buy_price_max": 1}]),
+        DummyResp(200, [{"item_id": "B", "city": "Caerleon", "sell_price_min": 2, "buy_price_max": 1}]),
+    ]
+    def fake_get(url, params=None, timeout=None):
+        return responses.pop(0)
+    session = types.SimpleNamespace(get=fake_get)
+    settings = types.SimpleNamespace(fetch_all_items=False)
+    rows = fetch_prices("europe", "A,B", "Caerleon", "1", session=session, settings=settings)
+    assert {r["item_id"] for r in rows} == {"A", "B"}

--- a/utils/catalog_provider.py
+++ b/utils/catalog_provider.py
@@ -68,7 +68,7 @@ def _filter_marketable(rows: list[dict]) -> list[str]:
             continue
         u = uid.strip().upper()
         # Exclusions: tests, unused, quest, internal placeholders
-        if any(tag in u for tag in ("TEST", "UNUSED", "QUESTITEM", "DUMMY")):
+        if any(tag in u for tag in ("TEST", "UNUSED", "QUESTITEM", "DUMMY", "_PH")):
             continue
         ids.append(u)
 


### PR DESCRIPTION
## Summary
- Guard API calls with URL-length-aware chunking and automatic 414 retry splitting
- Propagate “Items per Request” setting and tolerate per-chunk failures
- Exclude placeholder *_PH items from the catalog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7d181e65883308ea2c519c772ec0a