### PR TITLE
Aggregate market data and refine flip finder

### DIFF
--- a/tests/test_flip_builder.py
+++ b/tests/test_flip_builder.py
@@ -1,0 +1,37 @@
+import os, sys, pathlib
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_OPENGL", "software")
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from datetime import datetime, timezone
+
+from services.flip_engine import compute_flips
+
+
+def test_flip_uses_buy_max_and_sell_min():
+    rows = [
+        {
+            "item_id": "T4_SWORD",
+            "city": "Martlock",
+            "quality": 1,
+            "buy_price_max": 100,
+            "sell_price_min": 120,
+            "updated_dt": datetime.now(timezone.utc),
+        },
+        {
+            "item_id": "T4_SWORD",
+            "city": "Lymhurst",
+            "quality": 1,
+            "buy_price_max": 90,
+            "sell_price_min": 160,
+            "updated_dt": datetime.now(timezone.utc),
+        },
+    ]
+    flips = compute_flips(rows, cities=["Martlock", "Lymhurst"], qualities=[1], max_results=5, max_age_hours=24)
+    assert flips
+    best = flips[0]
+    assert best["buy_city"] == "Martlock"
+    assert best["sell_city"] == "Lymhurst"
+    assert best["buy"] == 100
+    assert best["sell"] == 160
+    assert best["spread"] == 60

--- a/tests/test_prices_mapping.py
+++ b/tests/test_prices_mapping.py
@@ -55,3 +55,34 @@ def test_spread_roi_and_dates():
     assert cell.text() == rel_age(dt)
     assert cell.toolTip() == fmt_tooltip(dt)
 
+
+def test_aggregate_prices_basic():
+    import pandas as pd
+    from services.market_prices import aggregate_prices
+
+    df = pd.DataFrame([
+        {
+            "item_id": "T4_SWORD",
+            "city": "Martlock",
+            "quality": 1,
+            "sell_price_min": 10000,
+            "buy_price_max": 9000,
+            "updated_dt": pd.Timestamp("2025-01-01"),
+        },
+        {
+            "item_id": "T4_SWORD",
+            "city": "Martlock",
+            "quality": 1,
+            "sell_price_min": 9900,
+            "buy_price_max": 9200,
+            "updated_dt": pd.Timestamp("2025-01-02"),
+        },
+    ])
+
+    out = aggregate_prices(df)
+    r = out.iloc[0]
+    assert r.sell_min == 9900
+    assert r.buy_max == 9200
+    assert r.spread == 700
+    assert 0.07 - 1e-6 <= r.roi <= 0.07 + 1e-6
+


### PR DESCRIPTION
## Summary
- aggregate normalized market rows into per-city min sell / max buy using pandas
- rework flip finder to use aggregated data and display explicit buy/sell columns
- add tests for price aggregation and flip route computation

## Testing
- `pytest tests/test_flip_builder.py::test_flip_uses_buy_max_and_sell_min -q`
- `pytest tests/test_prices_mapping.py::test_aggregate_prices_basic -q` *(fails: module skipped: PySide6 not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b857a25c3883309432995ed24b0b15