### PR TITLE
Add adaptive networking controls and caching

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,12 @@ aodp:
   chunk_size: 40
   rate_delay_seconds: 1
   timeout_seconds: 30
+max_concurrency: 4
+global_rate_per_sec: 2.0
+global_rate_capacity: 4
+cache_ttl_sec: 120
+city_batch_size: 3
+only_visible_first: true
 uploader:
   enabled: true
   ingest_base: "http+pow://albion-online-data.com"

--- a/datasources/__init__.py
+++ b/datasources/__init__.py
@@ -1,5 +1,11 @@
 """Data source clients for Albion Trade Optimizer."""
 
-from .aodp import AODPClient, AODPAPIError
-
+# Delay heavy imports to avoid circular dependencies
 __all__ = ["AODPClient", "AODPAPIError"]
+
+def __getattr__(name):  # pragma: no cover - simple lazy loader
+    if name in __all__:
+        from .aodp import AODPClient, AODPAPIError
+        globals().update({"AODPClient": AODPClient, "AODPAPIError": AODPAPIError})
+        return globals()[name]
+    raise AttributeError(name)

--- a/datasources/aodp.py
+++ b/datasources/aodp.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import json
 import requests
 from datasources.aodp_url import base_for, build_prices_request
+from services.netlimit import bucket
+from services.market_prices import _on_result
 
 # ---------------------------------------------------------------------------
 # Shared session used by higher level services.  Tests rely on predictable
@@ -94,7 +96,9 @@ class AODPClient:
         self._enforce_rate_limit()
         try:
             self.logger.debug(f"Making request to {url} with params {params}")
+            bucket.acquire()
             response = self.session.get(url, params=params, timeout=self.timeout)
+            _on_result(response.status_code)
             response.raise_for_status()
             data = response.json()
             self.logger.debug(

--- a/engine/config.py
+++ b/engine/config.py
@@ -146,6 +146,12 @@ class ConfigManager:
             'premium_enabled': True,
             'fetch_all_items': True,
             'items_per_request': 150,
+            'max_concurrency': 4,
+            'global_rate_per_sec': 2.0,
+            'global_rate_capacity': 4,
+            'cache_ttl_sec': 120,
+            'city_batch_size': 3,
+            'only_visible_first': True,
             'risk': {
                 'caerleon_high_risk': True
             },

--- a/services/http_cache.py
+++ b/services/http_cache.py
@@ -1,0 +1,14 @@
+import time
+from typing import Optional, Tuple, Dict
+
+_cache: Dict[str, Tuple[float, bytes, int, dict]] = {}
+
+def get_cached(url: str) -> Optional[Tuple[bytes, int, dict]]:
+    now = time.time()
+    hit = _cache.get(url)
+    if hit and hit[0] > now:
+        return hit[1], hit[2], hit[3]
+    return None
+
+def put_cached(url: str, body: bytes, status: int, headers: dict, ttl: int = 120) -> None:
+    _cache[url] = (time.time() + ttl, body, status, headers)

--- a/services/icons.py
+++ b/services/icons.py
@@ -6,6 +6,8 @@ import os, io, threading
 import requests
 from PySide6.QtGui import QPixmap, QIcon
 from PySide6.QtCore import QObject, Signal, QThreadPool, QRunnable, Slot
+from services.netlimit import bucket
+from services.market_prices import _on_result
 from platformdirs import user_cache_dir
 
 ICON_BASE = "https://render.albiononline.com/v1/item"  # e.g. /T4_SWORD.png?quality=3
@@ -43,7 +45,9 @@ class _FetchTask(QRunnable):
     @Slot()
     def run(self):
         try:
+            bucket.acquire()
             r = requests.get(self.url, timeout=15)
+            _on_result(r.status_code)
             r.raise_for_status()
             data = r.content
             # write once

--- a/services/market_prices.py
+++ b/services/market_prices.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import List, Dict
 from urllib.parse import urlencode
+import json
 import requests
 from requests import HTTPError
 import pandas as pd
@@ -17,6 +18,8 @@ from utils.params import qualities_to_csv, cities_to_list
 from utils.items import parse_items, items_catalog_codes
 from utils.timefmt import to_utc, now_utc_iso
 from core.signals import signals
+from services.netlimit import bucket
+from services.http_cache import get_cached, put_cached
 
 log = logging.getLogger(__name__)
 
@@ -31,11 +34,35 @@ LATEST_AGG_DF: pd.DataFrame | None = None
 MAX_URL_LEN = 1800
 
 
+def chunk_by_url(
+    items: list[str],
+    base: str,
+    cities: list[str],
+    qualities: list[int],
+    max_url: int = 1900,
+):
+    """Yield chunks of items whose request URL stays under ``max_url`` characters."""
+    cur: list[str] = []
+    for it in items:
+        test = ",".join(cur + [it])
+        url = (
+            f"{base}/api/v2/stats/prices/{test}.json"
+            f"?locations={','.join(cities)}&qualities={','.join(map(str, qualities))}"
+        )
+        if len(url) > max_url and cur:
+            yield cur
+            cur = [it]
+        else:
+            cur.append(it)
+    if cur:
+        yield cur
+
+
+# Backwards compatibility helpers for tests
 def _estimate_url_len(base: str, items: list[str], cities_csv: str, quals_csv: str) -> int:
-    """Estimate URL length for the given parameters."""
     path = f"{base}/api/v2/stats/prices/{','.join(items)}.json"
     q = urlencode({"locations": cities_csv, "qualities": quals_csv})
-    return len(path) + 1 + len(q)  # +1 for "?"
+    return len(path) + 1 + len(q)
 
 
 def _chunk_by_len_and_count(
@@ -46,28 +73,42 @@ def _chunk_by_len_and_count(
     max_count: int,
     max_url: int = MAX_URL_LEN,
 ) -> list[list[str]]:
-    """Chunk ``all_items`` by item count and estimated URL length."""
     chunks: list[list[str]] = []
     cur: list[str] = []
     for it in all_items:
         probe = cur + [it]
         if (
-            len(probe) > 0
-            and len(probe) <= max_count
+            len(probe) <= max_count
             and _estimate_url_len(base, probe, cities_csv, quals_csv) <= max_url
         ):
             cur = probe
-            continue
-        if cur:
-            chunks.append(cur)
-            cur = []
-        if _estimate_url_len(base, [it], cities_csv, quals_csv) <= max_url and max_count >= 1:
-            cur = [it]
         else:
-            chunks.append([it])
+            if cur:
+                chunks.append(cur)
+            cur = [it]
     if cur:
         chunks.append(cur)
     return chunks
+
+
+MIN_CONC, MAX_CONC = 1, 6
+_conc = 4
+_last429 = 0
+
+
+def _on_result(status_code: int) -> None:
+    global _conc, _last429
+    if status_code == 429:
+        _last429 += 1
+        _conc = max(MIN_CONC, _conc - 1)
+    else:
+        _last429 = max(0, _last429 - 1)
+        if _last429 == 0:
+            _conc = min(MAX_CONC, _conc + 1)
+
+
+def current_concurrency() -> int:
+    return _conc
 
 
 def fetch_prices(
@@ -81,6 +122,7 @@ def fetch_prices(
     cancel=lambda: False,
     fetch_all: bool | None = None,
 ):
+    global MAX_CONC, _conc
     sess = session or get_shared_session()
     typed = parse_items(items_edit_text)
     use_all = (
@@ -104,40 +146,82 @@ def fetch_prices(
     cities = cities_to_list(cities_sel, DEFAULT_CITIES)
     cities_csv = ",".join(cities)
     quals_csv = qualities_to_csv(qual_sel)
+    quals_list = [int(q) for q in quals_csv.split(",") if q]
     base = base_for(server)
 
-    # Respect settings.ItemsPerRequest if present (default 150)
-    chunk_size = int(
-        getattr(settings, "items_per_request", None)
-        or (settings.get("items_per_request") if isinstance(settings, dict) else None)
-        or 150
+    cache_ttl = int(
+        getattr(settings, "cache_ttl_sec", None)
+        or (settings.get("cache_ttl_sec") if isinstance(settings, dict) else None)
+        or 120
     )
-    max_workers = 4
-    chunks = _chunk_by_len_and_count(items, base, cities_csv, quals_csv, chunk_size)
+
+    max_conf = int(
+        getattr(settings, "max_concurrency", None)
+        or (settings.get("max_concurrency") if isinstance(settings, dict) else None)
+        or MAX_CONC
+    )
+    MAX_CONC = max(1, min(8, max_conf))
+    _conc = min(_conc, MAX_CONC)
+    bucket.rate = float(
+        getattr(settings, "global_rate_per_sec", None)
+        or (settings.get("global_rate_per_sec") if isinstance(settings, dict) else None)
+        or bucket.rate
+    )
+    bucket.capacity = int(
+        getattr(settings, "global_rate_capacity", None)
+        or (settings.get("global_rate_capacity") if isinstance(settings, dict) else None)
+        or bucket.capacity
+    )
+    bucket.tokens = bucket.capacity
+
+    chunks = list(chunk_by_url(items, base, cities, quals_list))
+    max_workers = current_concurrency()
     results: List[Dict] = []
 
     def pull(chunk, attempt=1):
         url, params = build_prices_request(base, chunk, cities, quals_csv)
+        full_url = requests.Request("GET", url, params=params).prepare().url
         log.info(
             "AODP GET: base=%s items=%d cities=%d quals=%s attempt=%d",
             base, len(chunk), len(cities), quals_csv, attempt,
         )
         log.debug("AODP URL: %s params=%s", url, params)
-        r = sess.get(url, params=params, timeout=(5,10))
-        if r.status_code == 414:
+        cached = get_cached(full_url)
+        if cached:
+            body, status, headers = cached
+            r = None
+        else:
+            bucket.acquire()
+            r = sess.get(url, params=params, timeout=(5, 10))
+            status = r.status_code
+            _on_result(status)
+            body = getattr(r, "content", b"")
+            headers = getattr(r, "headers", {})
+            if status == 200 and body:
+                put_cached(full_url, body, status, headers, ttl=cache_ttl)
+        if status == 414:
             if len(chunk) == 1:
                 log.warning("414 on single item; skipping id=%s", chunk[0])
                 return []
-            mid = max(1, len(chunk)//2)
+            mid = max(1, len(chunk) // 2)
             left = pull(chunk[:mid], 1)
             right = pull(chunk[mid:], 1)
             return (left or []) + (right or [])
-        if r.status_code in (429,500,502,503,504) and attempt <= 4:
-            time.sleep(0.5 * (2 ** (attempt-1)))
-            return pull(chunk, attempt+1)
-        r.raise_for_status()
-        data = r.json() or []
-        log.info("AODP RESP: status=%s records=%d", r.status_code, len(data))
+        if status in (429, 500, 502, 503, 504) and attempt <= 4:
+            time.sleep(0.5 * (2 ** (attempt - 1)))
+            return pull(chunk, attempt + 1)
+        if status != 200:
+            raise HTTPError(f"Unexpected status {status}")
+        try:
+            if body:
+                data = json.loads(body.decode("utf-8"))
+            elif r is not None:
+                data = r.json() or []
+            else:
+                data = []
+        except Exception:
+            data = []
+        log.info("AODP RESP: status=%s records=%d", status, len(data))
         return data
 
     failed = 0

--- a/services/netlimit.py
+++ b/services/netlimit.py
@@ -1,0 +1,24 @@
+import time
+import threading
+
+class TokenBucket:
+    def __init__(self, rate_per_sec: float = 2.0, capacity: int = 4):
+        self.rate = rate_per_sec
+        self.capacity = capacity
+        self.tokens = capacity
+        self.last = time.monotonic()
+        self.lock = threading.Lock()
+
+    def acquire(self, tokens: float = 1.0):
+        with self.lock:
+            now = time.monotonic()
+            self.tokens = min(self.capacity, self.tokens + (now - self.last) * self.rate)
+            self.last = now
+            need = tokens - self.tokens
+            if need > 0:
+                time.sleep(need / self.rate)
+                self.tokens = 0
+            else:
+                self.tokens -= tokens
+
+bucket = TokenBucket(rate_per_sec=2.0, capacity=4)


### PR DESCRIPTION
## Summary
- Implement global token bucket rate limiter and short-lived HTTP cache
- Add adaptive URL-based chunking with self-tuning concurrency for market price fetches
- Expose rate, concurrency and caching controls in settings and apply limiter to all network calls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b85a4a6de88330b6bf2caa025b29e3