### PR TITLE
Normalize market data and unify flip computations

### DIFF
--- a/gui/widgets/icons.py
+++ b/gui/widgets/icons.py
@@ -1,0 +1,46 @@
+"""Utility helper for loading and caching item icons."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from functools import lru_cache
+
+import requests
+from PySide6.QtGui import QIcon
+
+from utils.constants import ICON_BASE
+
+
+def _cache_dir() -> pathlib.Path:
+    base = pathlib.Path(os.path.expanduser("~"))
+    cache = base / ".albiontradeoptimizer" / "cache" / "icons"
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+@lru_cache(maxsize=512)
+def get_icon(item_dict: dict) -> QIcon:
+    """Return a QIcon for ``item_dict``.
+
+    This is a simplified helper used in tests; icons are cached on disk to
+    avoid repeated downloads.  If the download fails, an empty icon is
+    returned.
+    """
+
+    item_id = item_dict.get("item_id") or ""
+    quality = int(item_dict.get("quality") or 1)
+    url = ICON_BASE.format(id=item_id)
+    url = f"{url}?quality={quality}"
+    fname = _cache_dir() / f"{item_id}_{quality}.png"
+    if not fname.exists():
+        try:
+            resp = requests.get(url, timeout=5)
+            if resp.status_code == 200:
+                fname.write_bytes(resp.content)
+        except Exception:  # pragma: no cover - network errors ignored
+            return QIcon()
+    return QIcon(str(fname))
+
+
+__all__ = ["get_icon"]

--- a/tests/test_flip_engine.py
+++ b/tests/test_flip_engine.py
@@ -1,8 +1,7 @@
-import builtins
-
 from datetime import datetime, timedelta, timezone
 
 from services.flip_engine import compute_flips
+from utils.constants import MAX_DATA_AGE_HOURS
 
 
 def _sample_rows():
@@ -10,19 +9,23 @@ def _sample_rows():
     return [
         {
             "item_id": "T4_SWORD",
+            "item_name": "T4 Sword",
             "city": "Martlock",
             "quality": 1,
             "buy_price_max": 100,
             "sell_price_min": 0,
-            "updated_dt": (now - timedelta(minutes=5)).isoformat(),
+            "updated_dt": now - timedelta(minutes=5),
+            "updated_human": "5m",
         },
         {
             "item_id": "T4_SWORD",
+            "item_name": "T4 Sword",
             "city": "Lymhurst",
             "quality": 1,
             "buy_price_max": 0,
             "sell_price_min": 150,
-            "updated_dt": (now - timedelta(minutes=3)).isoformat(),
+            "updated_dt": now - timedelta(minutes=3),
+            "updated_human": "3m",
         },
     ]
 
@@ -32,23 +35,39 @@ def test_compute_flips_basic():
     flips = compute_flips(rows, cities=["Martlock", "Lymhurst"], qualities=[1], max_age_hours=24)
     assert flips
     flip = flips[0]
-    assert flip["item"] == "T4_SWORD"
-    assert flip["buy_city"] == "Martlock"
-    assert flip["sell_city"] == "Lymhurst"
+    assert flip["item_id"] == "T4_SWORD"
+    assert flip["from"] == "Martlock"
+    assert flip["to"] == "Lymhurst"
+    assert flip["buy"] == 100
+    assert flip["sell"] == 150
     assert flip["spread"] == 50
     assert round(flip["roi_pct"], 2) == 50.0
 
 
-def test_compute_flips_fallback(monkeypatch):
-    rows = _sample_rows()
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "pandas":
-            raise ImportError("no pandas")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-    flips = compute_flips(rows, cities=["Martlock", "Lymhurst"], qualities=[1], max_age_hours=24)
-    assert flips
-    assert flips[0]["spread"] == 50
+def test_compute_flips_stale_dropped():
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(hours=MAX_DATA_AGE_HOURS + 1)
+    rows = [
+        {
+            "item_id": "T4_SWORD",
+            "item_name": "T4 Sword",
+            "city": "Martlock",
+            "quality": 1,
+            "buy_price_max": 100,
+            "sell_price_min": 0,
+            "updated_dt": old,
+            "updated_human": "old",
+        },
+        {
+            "item_id": "T4_SWORD",
+            "item_name": "T4 Sword",
+            "city": "Lymhurst",
+            "quality": 1,
+            "buy_price_max": 0,
+            "sell_price_min": 150,
+            "updated_dt": now,
+            "updated_human": "now",
+        },
+    ]
+    flips = compute_flips(rows, cities=["Martlock", "Lymhurst"], qualities=[1])
+    assert flips == []

--- a/tests/test_ui_model_contract.py
+++ b/tests/test_ui_model_contract.py
@@ -1,0 +1,40 @@
+import os, sys, pathlib
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_OPENGL", "software")
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from datetime import datetime, timezone, timedelta
+
+from services.market_prices import normalize_and_dedupe
+from utils.timefmt import rel_age
+
+
+def test_rows_ready_for_ui():
+    now = datetime.now(timezone.utc)
+    raw = [
+        {
+            "item_id": "T4_BAG",
+            "city": "Lymhurst",
+            "quality": 1,
+            "sell_price_min": 150,
+            "sell_price_min_date": (now - timedelta(minutes=30)).isoformat(),
+            "buy_price_max": 100,
+            "buy_price_max_date": (now - timedelta(minutes=40)).isoformat(),
+        }
+    ]
+    rows = normalize_and_dedupe(raw)
+    assert len(rows) == 1
+    r = rows[0]
+    for key in (
+        "buy_price_max",
+        "sell_price_min",
+        "spread",
+        "roi_pct",
+        "updated_dt",
+        "updated_human",
+    ):
+        assert key in r
+    assert r["spread"] == r["sell_price_min"] - r["buy_price_max"]
+    expected_roi = 100 * r["spread"] / max(1, r["buy_price_max"])
+    assert abs(r["roi_pct"] - expected_roi) < 0.01
+    assert r["updated_human"] == rel_age(r["updated_dt"])

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,12 @@
+"""Shared constants for the Albion Trade Optimizer project."""
+
+from __future__ import annotations
+
+# Maximum age for market data records in hours (default: 180 days)
+MAX_DATA_AGE_HOURS = 4320  # 180 days
+
+# Base URL for item icons; ``{id}`` will be replaced with the item identifier.
+# The endpoint also accepts enchantment suffixes and ``?quality=`` parameters.
+ICON_BASE = "https://render.albiononline.com/v1/item/{id}.png"
+
+__all__ = ["MAX_DATA_AGE_HOURS", "ICON_BASE"]


### PR DESCRIPTION
## Summary
- introduce shared constants for icon URLs and maximum data age
- normalize market price rows with deduplication, freshness filtering, and precomputed spread/ROI fields
- rework flip engine to build flips from normalized rows and honor data age
- add simple icon helper with disk caching
- expand test coverage for normalization, flip engine, and UI data contract

## Testing
- `pytest tests/test_prices_mapping.py tests/test_flip_engine.py tests/test_ui_model_contract.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8656d0ae88330ae8357446ce02e77