### PR TITLE
Fix FlipFinder key usage and ROI handling

### DIFF
--- a/tests/test_flip_details_keys.py
+++ b/tests/test_flip_details_keys.py
@@ -1,0 +1,34 @@
+import os, sys, pathlib
+import pytest
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_OPENGL", "software")
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+flip_finder = pytest.importorskip("gui.widgets.flip_finder")
+FlipFinderWidget = flip_finder.FlipFinderWidget
+
+
+def test_detail_panel_uses_item_name(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    monkeypatch.setattr(flip_finder.ICON_PROVIDER, "get_icon_async", lambda *a, **k: None)
+    widget = FlipFinderWidget(None)
+    flip = {
+        "item_id": "T4_SWORD",
+        "item_name": "Sword",
+        "buy_city": "Martlock",
+        "sell_city": "Lymhurst",
+        "buy": 100,
+        "sell": 150,
+        "spread": 50,
+        "roi": 0.5,
+        "roi_pct": 50.0,
+        "updated": "just now",
+    }
+    widget.current_flips = [flip]
+    widget.populate_results_table([flip])
+    widget.results_table.selectRow(0)
+    widget.on_selection_changed()
+    text = widget.details_text.toPlainText()
+    assert "Sword" in text

--- a/tests/test_flipfinder_input_conversion.py
+++ b/tests/test_flipfinder_input_conversion.py
@@ -1,0 +1,53 @@
+import os, sys, pathlib
+import pytest
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_OPENGL", "software")
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+flip_finder = pytest.importorskip("gui.widgets.flip_finder")
+FlipFinderWorker = flip_finder.FlipFinderWorker
+from services import market_prices
+
+
+def test_trimmed_rows_and_roi_conversion(monkeypatch):
+    market_prices.LATEST_ROWS = [
+        {
+            "item_id": "T4_SWORD",
+            "city": "Martlock",
+            "quality": 1,
+            "buy_price_max": 100,
+            "sell_price_min": 200,
+            "updated_epoch_hours": 1.0,
+            "item_name": "Sword",
+        }
+    ]
+
+    captured = {}
+
+    def fake_build_flips(*, rows, items_filter, src_cities, dst_cities, qualities, min_profit, min_roi, max_age_hours, max_results):
+        captured["rows"] = rows
+        captured["min_roi"] = min_roi
+        return [], {}
+
+    monkeypatch.setattr(flip_finder, "build_flips", fake_build_flips)
+
+    params = {
+        "src_cities": ["Martlock"],
+        "dst_cities": ["Lymhurst"],
+        "items": None,
+        "qualities": None,
+        "min_profit": 0,
+        "min_roi": 5.0,
+        "max_age_hours": 24,
+        "max_results": 100,
+    }
+
+    worker = FlipFinderWorker(params)
+    worker.progress.emit = lambda *a, **k: None
+    worker.finished.emit = lambda *a, **k: None
+    worker.error.emit = lambda *a, **k: None
+    worker.run()
+
+    rows = captured["rows"]
+    assert rows and rows[0]["buy"] == 100 and rows[0]["sell"] == 200
+    assert captured["min_roi"] == 0.05


### PR DESCRIPTION
## Summary
- Normalize market price keys when trimming LATEST_ROWS and log results
- Convert ROI input from percent to decimal before calling the flip engine
- Use item_name/item_id in tables and detail panel to avoid KeyErrors
- Add regression tests for ROI conversion and detail rendering

## Testing
- `pytest tests/test_flipfinder_input_conversion.py tests/test_flip_details_keys.py` *(fails: libGL.so.1 missing; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b90e3f39c88330b5f36bcede1d4d33