### PR TITLE
Refactor networking and market price store

### DIFF
--- a/datasources/http.py
+++ b/datasources/http.py
@@ -1,9 +1,29 @@
+import threading
 import requests
-_session = None
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
-def get_shared_session():
-    global _session
-    if _session is None:
-        _session = requests.Session()
-        _session.headers.update({"User-Agent": "AlbionTradeOptimizer/1.0"})
-    return _session
+_session_local = threading.local()
+
+def _new_session() -> requests.Session:
+    s = requests.Session()
+    retry = Retry(
+        total=2,
+        connect=2,
+        read=2,
+        backoff_factor=0.3,
+        status_forcelist=[429, 500, 502, 503, 504],
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(pool_connections=20, pool_maxsize=50, max_retries=retry)
+    s.mount("http://", adapter)
+    s.mount("https://", adapter)
+    s.headers.update({"User-Agent": "AlbionTradeOptimizer/1.0"})
+    return s
+
+def get_shared_session() -> requests.Session:
+    s = getattr(_session_local, "session", None)
+    if s is None:
+        s = _new_session()
+        _session_local.session = s
+    return s

--- a/gui/threads.py
+++ b/gui/threads.py
@@ -28,7 +28,7 @@ class RefreshWorker(QObject):
         start = time.perf_counter()
         self.progress.emit(1, "Starting market refresh...")
         try:
-            from services.market_prices import fetch_prices
+            from services.market_prices import STORE
             from datasources.http import get_shared_session
             from core.health import mark_online_on_data_success
 
@@ -38,7 +38,7 @@ class RefreshWorker(QObject):
             fetch_all = self.params.get("fetch_all", True)
             items_text = self.itemsEdit.text() if hasattr(self, "itemsEdit") else ""
 
-            norm = fetch_prices(
+            norm = STORE.fetch_prices(
                 server=server,
                 items_edit_text=items_text,
                 cities_sel=cities_sel,

--- a/gui/widgets/flip_finder.py
+++ b/gui/widgets/flip_finder.py
@@ -25,7 +25,7 @@ import pandas as pd
 from datetime import datetime
 
 from services.flip_engine import build_flips
-from services import market_prices
+from services.market_prices import STORE
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class FlipFinderWorker(QThread):
     def run(self):
         try:
             self.progress.emit(10, "Preparing data...")
-            rows = market_prices.LATEST_ROWS or []
+            rows = STORE.latest_rows()
             trimmed = []
 
             def _num(row, *keys, default=0):

--- a/main.py
+++ b/main.py
@@ -24,13 +24,7 @@ from PySide6.QtGui import QIcon
 from gui.main_window import MainWindow
 from store.db import DatabaseManager
 from engine.config import ConfigManager
-
-
-def setup_data_directory() -> Path:
-    """Ensure the application data directory exists."""
-    data_dir = Path("data")
-    data_dir.mkdir(parents=True, exist_ok=True)
-    return data_dir
+from utils.paths import init_app_paths
 
 
 def main() -> int:
@@ -41,12 +35,11 @@ def main() -> int:
     app.setOrganizationName("Manus AI")
 
     try:
+        init_app_paths()
         config_manager = ConfigManager()
         config = config_manager.load_config()
 
         log.info("Starting Albion Trade Optimizer")
-
-        setup_data_directory()
 
         db_manager = DatabaseManager(config)
         db_manager.initialize_database()

--- a/services/flip_engine.py
+++ b/services/flip_engine.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 import logging
 import time
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Set
 
 from utils.constants import MAX_DATA_AGE_HOURS
 
@@ -71,7 +71,7 @@ def build_flips(
                 best_sell[key][city] = sell
                 updated[key][city] = upd
 
-    dedupe: Dict[Tuple[str, int, str, str], dict] = {}
+    dedupe: Dict[tuple[str, int, str, str], dict] = {}
     for (item, quality), buys in best_buy.items():
         sells = best_sell.get((item, quality), {})
         for src in src_set:

--- a/services/market_prices.py
+++ b/services/market_prices.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import logging
+import threading
 import time
 from typing import List, Dict
 from urllib.parse import urlencode
@@ -25,14 +26,225 @@ from services.http_cache import get_cached, put_cached
 log = logging.getLogger(__name__)
 
 DEFAULT_QUALITIES = "1,2,3,4,5"  # include 5 (Masterpiece)
-
-# Cache of the latest normalized and aggregated rows
-LATEST_ROWS: list[dict] = []
-LATEST_RAW_DF: pd.DataFrame | None = None
-LATEST_AGG_DF: pd.DataFrame | None = None
-
 # Conservative safety margin; many proxies reject > ~2000 bytes.
 MAX_URL_LEN = 1800
+MIN_CONC, MAX_CONC = 1, 6
+
+
+class MarketPriceStore:
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._latest_rows: list[dict] = []
+        self._raw_df: pd.DataFrame | None = None
+        self._agg_df: pd.DataFrame | None = None
+        self._conc = 4
+        self._last429 = 0
+        self.max_concurrency = MAX_CONC
+
+    def latest_rows(self) -> list[dict]:
+        with self._lock:
+            return list(self._latest_rows)
+
+    def _on_result(self, status_code: int) -> None:
+        if status_code == 429:
+            self._last429 += 1
+            self._conc = max(MIN_CONC, self._conc - 1)
+        else:
+            self._last429 = max(0, self._last429 - 1)
+            if self._last429 == 0:
+                self._conc = min(self.max_concurrency, self._conc + 1)
+
+    def current_concurrency(self) -> int:
+        with self._lock:
+            return self._conc
+
+    def fetch_prices(
+        self,
+        server,
+        items_edit_text,
+        cities_sel,
+        qual_sel,
+        session: requests.Session | None = None,
+        settings=None,
+        on_progress=None,
+        cancel=lambda: False,
+        fetch_all: bool | None = None,
+    ):
+        sess = session or get_shared_session()
+        typed = parse_items(items_edit_text)
+        use_all = (
+            fetch_all
+            if fetch_all is not None
+            else bool(getattr(settings, "fetch_all_items", True))
+        )
+        if (not typed) and not use_all:
+            log.info("No items to request (typed=%d, fetch_all=%s).", len(typed), use_all)
+            return []
+
+        catalog: list[str] = []
+        if (not typed) or use_all:
+            catalog = list(items_catalog_codes())
+        items = catalog if (not typed and use_all) else typed
+        log.info(
+            "Item selection: catalog=%d typed=%d fetch_all=%s -> final=%d",
+            len(catalog), len(typed), use_all, len(items),
+        )
+
+        cities = cities_to_list(cities_sel, DEFAULT_CITIES)
+        cities_csv = ",".join(cities)
+        quals_csv = qualities_to_csv(qual_sel)
+        quals_list = [int(q) for q in quals_csv.split(",") if q]
+        base = base_for(server)
+
+        cache_ttl = int(
+            getattr(settings, "cache_ttl_sec", None)
+            or (settings.get("cache_ttl_sec") if isinstance(settings, dict) else None)
+            or 120
+        )
+
+        max_conf = int(
+            getattr(settings, "max_concurrency", None)
+            or (settings.get("max_concurrency") if isinstance(settings, dict) else None)
+            or self.max_concurrency,
+        )
+        self.max_concurrency = max(1, min(8, max_conf))
+        self._conc = min(self._conc, self.max_concurrency)
+        bucket.rate = float(
+            getattr(settings, "global_rate_per_sec", None)
+            or (settings.get("global_rate_per_sec") if isinstance(settings, dict) else None)
+            or bucket.rate,
+        )
+        bucket.capacity = int(
+            getattr(settings, "global_rate_capacity", None)
+            or (settings.get("global_rate_capacity") if isinstance(settings, dict) else None)
+            or bucket.capacity,
+        )
+        bucket.tokens = bucket.capacity
+
+        chunks = list(chunk_by_url(items, base, cities, quals_list))
+        max_workers = self.current_concurrency()
+        results: List[Dict] = []
+
+        def pull(chunk, attempt=1):
+            url, params = build_prices_request(base, chunk, cities, quals_csv)
+            full_url = requests.Request("GET", url, params=params).prepare().url
+            log.info(
+                "AODP GET: base=%s items=%d cities=%d quals=%s attempt=%d",
+                base, len(chunk), len(cities), quals_csv, attempt,
+            )
+            log.debug("AODP URL: %s params=%s", url, params)
+            cached = get_cached(full_url)
+            if cached:
+                body, status, headers = cached
+                r = None
+            else:
+                bucket.acquire()
+                r = sess.get(url, params=params, timeout=(5, 10))
+                status = r.status_code
+                self._on_result(status)
+                body = getattr(r, "content", b"")
+                headers = getattr(r, "headers", {})
+                if status == 200 and body:
+                    put_cached(full_url, body, status, headers, ttl=cache_ttl)
+            if status == 414:
+                if len(chunk) == 1:
+                    log.warning("414 on single item; skipping id=%s", chunk[0])
+                    return []
+                mid = max(1, len(chunk) // 2)
+                left = pull(chunk[:mid], 1)
+                right = pull(chunk[mid:], 1)
+                return (left or []) + (right or [])
+            if status in (429, 500, 502, 503, 504) and attempt <= 4:
+                time.sleep(0.5 * (2 ** (attempt - 1)))
+                return pull(chunk, attempt + 1)
+            if status != 200:
+                raise HTTPError(f"Unexpected status {status}")
+            try:
+                if body:
+                    data = json.loads(body.decode("utf-8"))
+                elif r is not None:
+                    data = r.json() or []
+                else:
+                    data = []
+            except Exception:
+                data = []
+            log.info("AODP RESP: status=%s records=%d", status, len(data))
+            return data
+
+        failed = 0
+        failed_chunks: list[list[str]] = []
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            future_to_chunk = {ex.submit(pull, c): c for c in chunks}
+            total = len(future_to_chunk)
+            for idx, fut in enumerate(as_completed(future_to_chunk), 1):
+                if cancel():
+                    break
+                chunk = future_to_chunk[fut]
+                try:
+                    results.extend(fut.result())
+                except HTTPError as e:
+                    if getattr(e.response, "status_code", None) == 429:
+                        failed_chunks.append(chunk)
+                    failed += 1
+                    log.error("Chunk failed (%d/%d): %r", idx, total, e)
+                except Exception as e:
+                    failed += 1
+                    log.error("Chunk failed (%d/%d): %r", idx, total, e)
+                if on_progress:
+                    on_progress(int(idx / total * 100), f"Fetched {idx}/{total} chunks")
+        if failed_chunks:
+            log.info("Retry tail for %d 429-chunks at low rate", len(failed_chunks))
+            for c in failed_chunks:
+                try:
+                    data = pull(c, attempt=1)
+                    results.extend(data or [])
+                except Exception as e:
+                    log.warning("Tail retry failed: %r", e)
+                time.sleep(0.4)
+        if failed:
+            log.warning("Refresh completed with %d failed chunks (see logs)", failed)
+        norm = normalize_and_dedupe(results)
+        self.on_fetch_completed(norm)
+        return norm
+
+    def on_fetch_completed(self, norm_rows: list[dict]):
+        with self._lock:
+            self._raw_df = pd.DataFrame(norm_rows or [])
+            self._agg_df = self._raw_df  # already aggregated by normalization
+            self._latest_rows = norm_rows
+        signals.market_rows_updated.emit(self.latest_rows())
+        emit_summary(self._agg_df)
+
+    def clear(self):
+        with self._lock:
+            self._latest_rows.clear()
+            self._raw_df = None
+            self._agg_df = None
+            self._conc = 4
+            self._last429 = 0
+
+
+STORE = MarketPriceStore()
+
+
+def fetch_prices(*args, **kwargs):
+    return STORE.fetch_prices(*args, **kwargs)
+
+
+def _on_result(status_code: int) -> None:
+    STORE._on_result(status_code)
+
+
+def current_concurrency() -> int:
+    return STORE.current_concurrency()
+
+
+def latest_rows() -> list[dict]:
+    return STORE.latest_rows()
+
+
+def on_fetch_completed(norm_rows: list[dict]):
+    STORE.on_fetch_completed(norm_rows)
 
 
 def chunk_by_url(
@@ -90,176 +302,6 @@ def _chunk_by_len_and_count(
     if cur:
         chunks.append(cur)
     return chunks
-
-
-MIN_CONC, MAX_CONC = 1, 6
-_conc = 4
-_last429 = 0
-
-
-def _on_result(status_code: int) -> None:
-    global _conc, _last429
-    if status_code == 429:
-        _last429 += 1
-        _conc = max(MIN_CONC, _conc - 1)
-    else:
-        _last429 = max(0, _last429 - 1)
-        if _last429 == 0:
-            _conc = min(MAX_CONC, _conc + 1)
-
-
-def current_concurrency() -> int:
-    return _conc
-
-
-def fetch_prices(
-    server,
-    items_edit_text,
-    cities_sel,
-    qual_sel,
-    session: requests.Session | None = None,
-    settings=None,
-    on_progress=None,
-    cancel=lambda: False,
-    fetch_all: bool | None = None,
-):
-    global MAX_CONC, _conc
-    sess = session or get_shared_session()
-    typed = parse_items(items_edit_text)
-    use_all = (
-        fetch_all
-        if fetch_all is not None
-        else bool(getattr(settings, "fetch_all_items", True))
-    )
-    if (not typed) and not use_all:
-        log.info("No items to request (typed=%d, fetch_all=%s).", len(typed), use_all)
-        return []
-
-    catalog: list[str] = []
-    if (not typed) or use_all:
-        catalog = list(items_catalog_codes())
-    items = catalog if (not typed and use_all) else typed
-    log.info(
-        "Item selection: catalog=%d typed=%d fetch_all=%s -> final=%d",
-        len(catalog), len(typed), use_all, len(items),
-    )
-
-    cities = cities_to_list(cities_sel, DEFAULT_CITIES)
-    cities_csv = ",".join(cities)
-    quals_csv = qualities_to_csv(qual_sel)
-    quals_list = [int(q) for q in quals_csv.split(",") if q]
-    base = base_for(server)
-
-    cache_ttl = int(
-        getattr(settings, "cache_ttl_sec", None)
-        or (settings.get("cache_ttl_sec") if isinstance(settings, dict) else None)
-        or 120
-    )
-
-    max_conf = int(
-        getattr(settings, "max_concurrency", None)
-        or (settings.get("max_concurrency") if isinstance(settings, dict) else None)
-        or MAX_CONC
-    )
-    MAX_CONC = max(1, min(8, max_conf))
-    _conc = min(_conc, MAX_CONC)
-    bucket.rate = float(
-        getattr(settings, "global_rate_per_sec", None)
-        or (settings.get("global_rate_per_sec") if isinstance(settings, dict) else None)
-        or bucket.rate
-    )
-    bucket.capacity = int(
-        getattr(settings, "global_rate_capacity", None)
-        or (settings.get("global_rate_capacity") if isinstance(settings, dict) else None)
-        or bucket.capacity
-    )
-    bucket.tokens = bucket.capacity
-
-    chunks = list(chunk_by_url(items, base, cities, quals_list))
-    max_workers = current_concurrency()
-    results: List[Dict] = []
-
-    def pull(chunk, attempt=1):
-        url, params = build_prices_request(base, chunk, cities, quals_csv)
-        full_url = requests.Request("GET", url, params=params).prepare().url
-        log.info(
-            "AODP GET: base=%s items=%d cities=%d quals=%s attempt=%d",
-            base, len(chunk), len(cities), quals_csv, attempt,
-        )
-        log.debug("AODP URL: %s params=%s", url, params)
-        cached = get_cached(full_url)
-        if cached:
-            body, status, headers = cached
-            r = None
-        else:
-            bucket.acquire()
-            r = sess.get(url, params=params, timeout=(5, 10))
-            status = r.status_code
-            _on_result(status)
-            body = getattr(r, "content", b"")
-            headers = getattr(r, "headers", {})
-            if status == 200 and body:
-                put_cached(full_url, body, status, headers, ttl=cache_ttl)
-        if status == 414:
-            if len(chunk) == 1:
-                log.warning("414 on single item; skipping id=%s", chunk[0])
-                return []
-            mid = max(1, len(chunk) // 2)
-            left = pull(chunk[:mid], 1)
-            right = pull(chunk[mid:], 1)
-            return (left or []) + (right or [])
-        if status in (429, 500, 502, 503, 504) and attempt <= 4:
-            time.sleep(0.5 * (2 ** (attempt - 1)))
-            return pull(chunk, attempt + 1)
-        if status != 200:
-            raise HTTPError(f"Unexpected status {status}")
-        try:
-            if body:
-                data = json.loads(body.decode("utf-8"))
-            elif r is not None:
-                data = r.json() or []
-            else:
-                data = []
-        except Exception:
-            data = []
-        log.info("AODP RESP: status=%s records=%d", status, len(data))
-        return data
-
-    failed = 0
-    failed_chunks: list[list[str]] = []
-    with ThreadPoolExecutor(max_workers=max_workers) as ex:
-        future_to_chunk = {ex.submit(pull, c): c for c in chunks}
-        total = len(future_to_chunk)
-        for idx, fut in enumerate(as_completed(future_to_chunk), 1):
-            if cancel():
-                break
-            chunk = future_to_chunk[fut]
-            try:
-                results.extend(fut.result())
-            except HTTPError as e:
-                if getattr(e.response, "status_code", None) == 429:
-                    failed_chunks.append(chunk)
-                failed += 1
-                log.error("Chunk failed (%d/%d): %r", idx, total, e)
-            except Exception as e:
-                failed += 1
-                log.error("Chunk failed (%d/%d): %r", idx, total, e)
-            if on_progress:
-                on_progress(int(idx / total * 100), f"Fetched {idx}/{total} chunks")
-    if failed_chunks:
-        log.info("Retry tail for %d 429-chunks at low rate", len(failed_chunks))
-        for c in failed_chunks:
-            try:
-                data = pull(c, attempt=1)  # pull already has backoff
-                results.extend(data or [])
-            except Exception as e:
-                log.warning("Tail retry failed: %r", e)
-            time.sleep(0.4)
-    if failed:
-        log.warning("Refresh completed with %d failed chunks (see logs)", failed)
-    norm = normalize_and_dedupe(results)
-    on_fetch_completed(norm)
-    return norm
 
 
 def normalize_and_dedupe(rows: List[Dict]) -> List[Dict]:
@@ -408,16 +450,6 @@ def emit_summary(df: pd.DataFrame):
     signals.market_data_ready.emit(summary)
 
 
-def on_fetch_completed(norm_rows: list[dict]):
-    """Cache and emit latest normalized rows."""
-    global LATEST_ROWS, LATEST_RAW_DF, LATEST_AGG_DF
-    LATEST_RAW_DF = pd.DataFrame(norm_rows or [])
-    LATEST_AGG_DF = LATEST_RAW_DF  # already aggregated by normalization
-    LATEST_ROWS = norm_rows
-    signals.market_rows_updated.emit(LATEST_ROWS)
-    emit_summary(LATEST_AGG_DF)
-
-
 __all__ = [
     "fetch_prices",
     "normalize_and_dedupe",
@@ -427,7 +459,6 @@ __all__ = [
     "top_opportunities",
     "emit_summary",
     "on_fetch_completed",
-    "LATEST_ROWS",
-    "LATEST_RAW_DF",
-    "LATEST_AGG_DF",
+    "latest_rows",
+    "STORE",
 ]

--- a/test_database.py
+++ b/test_database.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(project_root))
 
 from engine.config import ConfigManager
 from store.db import DatabaseManager
+from utils.paths import init_app_paths
 
 
 def test_database():
@@ -24,7 +25,8 @@ def test_database():
     config_manager = ConfigManager()
     config = config_manager.load_config()
     print(f"✓ Configuration loaded")
-    
+
+    init_app_paths()
     # Initialize database
     db_manager = DatabaseManager(config)
     db_manager.initialize_database()

--- a/tests/test_flipfinder_input_conversion.py
+++ b/tests/test_flipfinder_input_conversion.py
@@ -6,11 +6,12 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 flip_finder = pytest.importorskip("gui.widgets.flip_finder")
 FlipFinderWorker = flip_finder.FlipFinderWorker
-from services import market_prices
+from services.market_prices import STORE
 
 
 def test_trimmed_rows_and_roi_conversion(monkeypatch):
-    market_prices.LATEST_ROWS = [
+    STORE.clear()
+    STORE._latest_rows = [
         {
             "item_id": "T4_SWORD",
             "city": "Martlock",

--- a/tests/test_refactors.py
+++ b/tests/test_refactors.py
@@ -1,0 +1,75 @@
+import logging
+import threading
+import time
+import pytest
+from requests import exceptions as rqexc
+
+from services.netlimit import TokenBucket
+from core import health
+from datasources import aodp as aodp_mod
+from datasources.http import get_shared_session
+from services.market_prices import STORE
+
+
+def test_token_bucket_no_deadlock():
+    bucket = TokenBucket(rate_per_sec=1.0, capacity=1)
+    times = []
+
+    def worker():
+        bucket.acquire()
+        times.append(time.time())
+
+    t1 = threading.Thread(target=worker)
+    t2 = threading.Thread(target=worker)
+    start = time.time()
+    t1.start(); t2.start()
+    t1.join(2)
+    t2.join(2)
+    end = time.time()
+    assert len(times) == 2
+    assert end - start < 1.8
+
+
+def test_ping_aodp_timeout_logs(monkeypatch, caplog):
+    class DummySession:
+        def get(self, *a, **k):
+            raise rqexc.Timeout("boom")
+    monkeypatch.setattr(health, "get_shared_session", lambda: DummySession())
+    with caplog.at_level(logging.WARNING):
+        ok = health.ping_aodp("europe")
+    assert ok is False
+    assert "AODP ping failed" in caplog.text
+
+
+def test_process_history_record_error_handling(monkeypatch):
+    client = aodp_mod.AODPClient({})
+    assert client._process_history_record({"location": "Lymhurst"}) is None
+
+    class DummyDate:
+        @staticmethod
+        def fromisoformat(s):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(aodp_mod, "datetime", DummyDate)
+    with pytest.raises(RuntimeError):
+        client._process_history_record({
+            "item_type_id": "T4", "location": "Lymhurst", "avg_price": 1, "timestamp": "2020-01-01T00:00:00Z"
+        })
+
+
+def test_get_shared_session_thread_local():
+    main_sess = get_shared_session()
+    other = []
+    def worker():
+        other.append(get_shared_session())
+    t = threading.Thread(target=worker)
+    t.start(); t.join()
+    assert other and other[0] is not main_sess
+
+
+def test_latest_rows_returns_copy():
+    STORE.clear()
+    STORE._latest_rows = [{"a": 1}]
+    out = STORE.latest_rows()
+    out.append({"a": 2})
+    assert STORE.latest_rows() == [{"a": 1}]

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -17,19 +17,18 @@ APP_VENDOR = "Albion"
 DATA_DIR = Path(user_data_dir(APP_NAME, APP_VENDOR))
 LOG_DIR = Path(user_log_dir(APP_NAME, APP_VENDOR))
 DB_DIR = DATA_DIR / "data"
-
-# Ensure directories exist
-for _p in (DATA_DIR, LOG_DIR, DB_DIR):
-    _p.mkdir(parents=True, exist_ok=True)
-
 DB_PATH = DB_DIR / "albion_trade.db"
 CONFIG_PATH = DATA_DIR / "config.yaml"
 
-# Migrate legacy files if present
-legacy_config = Path("config.yaml")
-if not CONFIG_PATH.exists() and legacy_config.exists():
-    CONFIG_PATH.write_bytes(legacy_config.read_bytes())
 
-legacy_db = Path("data") / "albion_trade.db"
-if not DB_PATH.exists() and legacy_db.exists():
-    DB_PATH.write_bytes(legacy_db.read_bytes())
+def init_app_paths() -> None:
+    for _p in (DATA_DIR, LOG_DIR, DB_DIR):
+        _p.mkdir(parents=True, exist_ok=True)
+
+    legacy_config = Path("config.yaml")
+    if not CONFIG_PATH.exists() and legacy_config.exists():
+        CONFIG_PATH.write_bytes(legacy_config.read_bytes())
+
+    legacy_db = Path("data") / "albion_trade.db"
+    if not DB_PATH.exists() and legacy_db.exists():
+        DB_PATH.write_bytes(legacy_db.read_bytes())


### PR DESCRIPTION
## Summary
- Release token bucket mutex before sleeping to avoid deadlocks
- Narrow network and schema exception handling for clearer failures
- Introduce thread-local HTTP sessions and encapsulated market price store
- Move path initialization to explicit bootstrap and clean up imports
- Add regression tests for token bucket, AODP ping, record parsing, session isolation, and store copying

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b925c362e8833080a48f8e03947d13