### PR TITLE
Refactor HTTP utilities and improve refresh metrics

### DIFF
--- a/datasources/http.py
+++ b/datasources/http.py
@@ -18,7 +18,12 @@ def _new_session() -> requests.Session:
     adapter = HTTPAdapter(pool_connections=20, pool_maxsize=50, max_retries=retry)
     s.mount("http://", adapter)
     s.mount("https://", adapter)
-    s.headers.update({"User-Agent": "AlbionTradeOptimizer/1.0"})
+    s.headers.update({
+        "User-Agent": "AlbionTradeOptimizer/1.0 (+https://github.com/<repo>; contact: you@example.com)",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+    })
     return s
 
 def get_shared_session() -> requests.Session:

--- a/gui/threads.py
+++ b/gui/threads.py
@@ -52,11 +52,15 @@ class RefreshWorker(QObject):
             if norm:
                 mark_online_on_data_success()
             elapsed = time.perf_counter() - start
+            records = len(norm)
+            unique_items = len({r.get("item_id") for r in norm if "item_id" in r})
             log.info(
-                "Market refresh completed: items=%s records=%s elapsed=%.2fs",
-                len(norm), len(norm), elapsed,
+                "Market refresh completed: items=%d records=%d elapsed=%.2fs",
+                unique_items,
+                records,
+                elapsed,
             )
-            summary = {"items": len(norm), "records": len(norm)}
+            summary = {"records": records, "unique_items": unique_items}
             self.finished.emit({"ok": True, "elapsed": elapsed, "result": summary})
         except Exception as e:  # pragma: no cover - unexpected errors
             log.exception("RefreshWorker failed: %s", e)

--- a/gui/widgets/market_prices.py
+++ b/gui/widgets/market_prices.py
@@ -243,7 +243,7 @@ class MarketPricesWidget(QWidget):
         self.main_window.set_status(f"Refresh done in {elapsed:.2f}s")
         self.logger.info(
             "Market refresh completed: items=%s records=%s elapsed=%.2fs",
-            payload.get("result", {}).get("items"),
+            payload.get("result", {}).get("unique_items"),
             payload.get("result", {}).get("records"),
             elapsed,
         )

--- a/tests/test_dashboard_updates.py
+++ b/tests/test_dashboard_updates.py
@@ -58,7 +58,7 @@ def test_dashboard_updates():
             pass
 
     mpw = MarketPricesWidget(DummyMain())
-    mpw.on_refresh_done({"elapsed": 0, "result": {"items": 0, "records": 0}})
+    mpw.on_refresh_done({"elapsed": 0, "result": {"unique_items": 0, "records": 0}})
     app.processEvents()
 
     assert len(updates) == 1

--- a/tests/test_fetch_cancel.py
+++ b/tests/test_fetch_cancel.py
@@ -1,0 +1,38 @@
+import types
+import types
+import time
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services import market_prices as mp
+
+
+class DummyResp:
+    def __init__(self, status, data=None):
+        self.status_code = status
+        self._data = data or []
+
+    def json(self):
+        return self._data
+
+
+def test_fetch_prices_cancel(monkeypatch):
+    # Prepare session that records calls
+    calls = []
+
+    def fake_get(url, params=None, timeout=None):
+        calls.append(url)
+        time.sleep(0.01)
+        return DummyResp(200, [])
+
+    session = types.SimpleNamespace(get=fake_get)
+    settings = types.SimpleNamespace(fetch_all_items=False)
+
+    monkeypatch.setattr(mp, "chunk_by_url", lambda items, base, cities, qualities, max_url=None: [["A"], ["B"], ["C"], ["D"]])
+
+    def cancel():
+        return len(calls) >= 1
+
+    rows = mp.fetch_prices("europe", "A,B,C,D", "Caerleon", "1", session=session, settings=settings, cancel=cancel)
+    assert rows == []
+    assert len(calls) < 4

--- a/tests/test_http_cache.py
+++ b/tests/test_http_cache.py
@@ -1,0 +1,21 @@
+import threading
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.http_cache import cache_set, cache_get, HTTP_CACHE_CAPACITY
+
+
+def test_http_cache_thread_safe_capacity():
+    def worker(n):
+        key = f"k{n}"
+        cache_set(key, str(n).encode())
+        cache_get(key)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(HTTP_CACHE_CAPACITY * 2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    hits = sum(1 for i in range(HTTP_CACHE_CAPACITY * 2) if cache_get(f"k{i}") is not None)
+    assert hits <= HTTP_CACHE_CAPACITY

--- a/tests/test_refactors.py
+++ b/tests/test_refactors.py
@@ -67,6 +67,18 @@ def test_get_shared_session_thread_local():
     assert other and other[0] is not main_sess
 
 
+def test_aodp_client_uses_shared_session():
+    sess = get_shared_session()
+    client = aodp_mod.AODPClient({})
+    assert client.session is get_shared_session()
+
+
+def test_shared_session_headers():
+    sess = get_shared_session()
+    assert sess.headers.get("Accept") == "application/json"
+    assert "AlbionTradeOptimizer" in sess.headers.get("User-Agent", "")
+
+
 def test_latest_rows_returns_copy():
     STORE.clear()
     STORE._latest_rows = [{"a": 1}]

--- a/tests/test_refresh_worker.py
+++ b/tests/test_refresh_worker.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pathlib
+import logging
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_OPENGL", "software")
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+try:
+    from PySide6.QtWidgets import QApplication
+except Exception:  # pragma: no cover
+    pytest.skip("PySide6 not available", allow_module_level=True)
+
+from gui.threads import RefreshWorker
+
+
+def test_refresh_worker_summary(monkeypatch, caplog):
+    app = QApplication.instance() or QApplication([])
+
+    rows = [{"item_id": "A"}, {"item_id": "A"}, {"item_id": "B"}]
+
+    class DummyStore:
+        def fetch_prices(self, **kwargs):
+            return rows
+
+    monkeypatch.setattr("gui.threads.STORE", DummyStore())
+    monkeypatch.setattr("gui.threads.get_shared_session", lambda: None)
+    monkeypatch.setattr("gui.threads.mark_online_on_data_success", lambda: None)
+
+    worker = RefreshWorker({"server": "europe"}, settings={})
+    payloads = []
+    worker.finished.connect(lambda p: payloads.append(p))
+
+    with caplog.at_level(logging.INFO):
+        worker.run()
+
+    assert "items=2 records=3" in caplog.text
+    assert payloads and payloads[0]["result"]["unique_items"] == 2
+    assert payloads[0]["result"]["records"] == 3

--- a/tests/test_url_chunking.py
+++ b/tests/test_url_chunking.py
@@ -3,7 +3,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import types
 
-from services.market_prices import _chunk_by_len_and_count, _estimate_url_len, fetch_prices
+from services.market_prices import _chunk_by_len_and_count, _estimate_url_len, fetch_prices, chunk_by_url, MAX_URL_LEN
 
 class DummyResp:
     def __init__(self, status, data=None):
@@ -23,6 +23,20 @@ def test_chunk_by_len_and_count_respects_url():
     items = ["X" * 500, "Y" * 500]
     chunks = _chunk_by_len_and_count(items, base, cities_csv, quals_csv, 10, max_url=1000)
     assert all(_estimate_url_len(base, c, cities_csv, quals_csv) <= 1000 for c in chunks)
+
+
+def test_chunk_by_url_uses_constant():
+    base = "https://example.com"
+    cities = ["Caerleon"]
+    quals = [1]
+    items = [f"ITEM{i}" for i in range(100)]
+    chunks = list(chunk_by_url(items, base, cities, quals))
+    cities_csv = ",".join(cities)
+    quals_csv = ",".join(map(str, quals))
+    assert all(
+        _estimate_url_len(base, c, cities_csv, quals_csv) <= MAX_URL_LEN
+        for c in chunks
+    )
 
 
 def test_auto_split_on_414(monkeypatch):


### PR DESCRIPTION
## Summary
- Align URL chunking with `MAX_URL_LEN` and add robust cancellation and error handling for market price fetches
- Replace simple dict cache with thread-safe bounded LRU cache
- Report unique item counts in refresh logs and results
- Share HTTP session with compliant default headers across clients, decoupling datasource from services

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b92e6187cc8330976d394e3f2e95c6