### PR TITLE
Improve AODP price record exception handling

### DIFF
--- a/datasources/aodp.py
+++ b/datasources/aodp.py
@@ -205,8 +205,14 @@ class AODPClient:
                 'observed_at_utc': observed_at_utc
             }
             
-        except Exception as e:
-            self.logger.warning(f"Failed to process price record: {e}")
+        except KeyError as e:
+            self.logger.warning(f"KeyError processing price record: {e}")
+            return None
+        except TypeError as e:
+            self.logger.warning(f"TypeError processing price record: {e}")
+            return None
+        except ValueError as e:
+            self.logger.warning(f"ValueError processing price record: {e}")
             return None
     
     def get_historical_prices(self, item_ids: List[str], locations: Optional[List[str]] = None,


### PR DESCRIPTION
## Summary
- log specific KeyError, TypeError, and ValueError cases in `_process_price_record`
- return `None` only after recording the exception type

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9312e03408330b06c489fb6a2c24b